### PR TITLE
transparent title, still shows background image

### DIFF
--- a/skyfield/documentation/_static/style.css
+++ b/skyfield/documentation/_static/style.css
@@ -67,7 +67,10 @@ h1, h2 {
     width: 480px;
     height: 240px;
     background: #ffffff url('logo.png') no-repeat left top;
-    text-indent:-9999px;  /* so screen reader will still read the title */
+    color: transparent;
+}
+#skyfield h1 > a.headerlink {
+    display: none;
 }
 .headerlink {
     color: #f8f8ff;


### PR DESCRIPTION
an alternative to moving the text off the page.

I was playing with making sphinx docs for my own project, thought I'd share this very trivial alternative. very low on your celestial priority list i'm sure, haha.
