### PR TITLE
add methods to get Earth latlon for Apparents and EarthSatellites

### DIFF
--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -98,7 +98,7 @@ satellite is flying:
 
 .. testcode::
 
-    topos = sat.over_topos(JulianDate(utc=tup))
+    topos = sat.over_location(JulianDate(utc=tup))
 
     print(topos.latitude)
     print(topos.longitude)

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -93,6 +93,21 @@ See :doc:`positions` to learn more about these possibilities:
     01h 55m 39.18s
     +62deg 55' 57.4"
 
+Finally, you can find the point on the Earth's surface over which the
+satellite is flying:
+
+.. testcode::
+
+    topos = sat.over_topos(JulianDate(utc=tup))
+
+    print(topos.latitude)
+    print(topos.longitude)
+
+.. testoutput::
+
+    51deg 20' 12.0"
+    -84deg 09' 38.5"
+
 The standard SGP4 theory of satellite motion that Skyfield uses
 is a rough enough model of the near-Earth environment
 that it can only predict a satellite position

--- a/skyfield/documentation/positions.rst
+++ b/skyfield/documentation/positions.rst
@@ -45,6 +45,7 @@ together with all of the attributes and methods that they support:
     Apparent position only
      │
      └── `altaz(…) <api.html#skyfield.positionlib.Apparent.altaz>`_            →   alt, az, distance
+     └── `over_topos(…) <api.html#skyfield.positionlib.Apparent.over_topos>`_  →   topos
 
     Angle like ra, dec, alt, and az
      │
@@ -114,6 +115,10 @@ as its argument and return a corresponding number of positions.
     astrometric = boston.at(jd).observe(mars)
     apparent = boston.at(jd).observe(mars).apparent()
 
+    # Earth location where in zenith at date
+
+    topos = apparent.over_topos(jd)
+
 **The stars**
   Stars and other fixed objects with catalog coordinates
   are able to generate their current astrometric position
@@ -172,6 +177,10 @@ as its argument and return a corresponding number of positions.
     # Topocentric
 
     #apparent = boston.gcrs(jd).observe(satellite)
+
+    # Earth location over which the satellite will be
+
+    topos = satellite.over_topos(jd)
 
 Read :doc:`time` for more information
 about how to build dates and pass them to planets and satellites

--- a/skyfield/documentation/positions.rst
+++ b/skyfield/documentation/positions.rst
@@ -44,8 +44,8 @@ together with all of the attributes and methods that they support:
 
     Apparent position only
      │
-     └── `altaz(…) <api.html#skyfield.positionlib.Apparent.altaz>`_            →   alt, az, distance
-     └── `over_topos(…) <api.html#skyfield.positionlib.Apparent.over_topos>`_  →   topos
+     └── `altaz(…) <api.html#skyfield.positionlib.Apparent.altaz>`_               →   alt, az, distance
+     └── `over_location(…) <api.html#skyfield.positionlib.Apparent.over_topos>`_  →   topos
 
     Angle like ra, dec, alt, and az
      │
@@ -117,7 +117,7 @@ as its argument and return a corresponding number of positions.
 
     # Earth location where in zenith at date
 
-    topos = apparent.over_topos()
+    topos = apparent.over_location()
 
 **The stars**
   Stars and other fixed objects with catalog coordinates
@@ -156,7 +156,7 @@ as its argument and return a corresponding number of positions.
   .. testsetup::
 
     tle_text = """
-    ISS (ZARYA)             
+    ISS (ZARYA)
     1 25544U 98067A   14020.93268519  .00009878  00000-0  18200-3 0  5082
     2 25544  51.6498 109.4756 0003572  55.9686 274.8005 15.49815350868473
     """
@@ -180,7 +180,7 @@ as its argument and return a corresponding number of positions.
 
     # Earth location over which the satellite will be
 
-    topos = satellite.over_topos(jd)
+    topos = satellite.over_location(jd)
 
 Read :doc:`time` for more information
 about how to build dates and pass them to planets and satellites

--- a/skyfield/documentation/positions.rst
+++ b/skyfield/documentation/positions.rst
@@ -117,7 +117,7 @@ as its argument and return a corresponding number of positions.
 
     # Earth location where in zenith at date
 
-    topos = apparent.over_topos(jd)
+    topos = apparent.over_topos()
 
 **The stars**
   Stars and other fixed objects with catalog coordinates

--- a/skyfield/positionlib.py
+++ b/skyfield/positionlib.py
@@ -329,14 +329,14 @@ class Apparent(ICRS):
 
         return alt, Angle(radians=az), Distance(r_au)
 
-    def over_topos(self):
+    def over_location(self):
         """
         Return a Topos instance for the point on the Earth over which
         the body at this position is in the zenith.
 
         >>> from skyfield.api import earth, JulianDate, sun
         >>> e = earth(JulianDate(utc=(2015, 1, 1, 0, 0, 0)))
-        >>> topos = e.observe(sun).apparent().over_topos()
+        >>> topos = e.observe(sun).apparent().over_location()
         >>> topos.latitude
         <Angle -23deg 03' 33.3">
         >>> topos.longitude

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -89,7 +89,7 @@ class EarthSatellite(object):
         return g
 
     @takes_julian_date
-    def over_topos(self, jd):
+    def over_location(self, jd):
         """Return a Topos instance for the point on the Earth over which
         this satellite will be at the given date.
 
@@ -98,7 +98,7 @@ class EarthSatellite(object):
         ... "1 25544U 98067A   15058.48161588  .00023857  00000-0  35618-3 0  9991\n"
         ... "2 25544  51.6478 271.9610 0008043  54.4849  18.6646 15.54887163930964")
         >>> iss = earth.satellite(tle)
-        >>> topos = iss.over_topos(JulianDate(utc=(2015, 2, 27, 22, 22, 0)))
+        >>> topos = iss.over_location(JulianDate(utc=(2015, 2, 27, 22, 22, 0)))
         >>> topos.latitude
         <Angle 49deg 19' 48.3">
         >>> topos.longitude

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -7,8 +7,8 @@ from sgp4.propagation import sgp4
 
 from .constants import AU_KM, DAY_S, T0, tau
 from .functions import rot_x, rot_y, rot_z
-from .positionlib import Apparent, Geocentric, ITRF_to_GCRS
-from .timelib import JulianDate, Timescale
+from .positionlib import Apparent, Geocentric, GCRS_to_Topos, ITRF_to_GCRS
+from .timelib import JulianDate, takes_julian_date, Timescale
 
 # important ones:
 # jdsatepoch
@@ -87,6 +87,24 @@ class EarthSatellite(object):
         g = Geocentric(position_au, velociy_au_per_d, jd)
         g.sgp4_error = error
         return g
+
+    @takes_julian_date
+    def over_topos(self, jd):
+        """Return a Topos instance for the point on the Earth over which
+        this satellite will be at the given date.
+
+        >>> from skyfield.api import earth, JulianDate
+        >>> tle = ("ISS (ZARYA)\n"
+        ... "1 25544U 98067A   15058.48161588  .00023857  00000-0  35618-3 0  9991\n"
+        ... "2 25544  51.6478 271.9610 0008043  54.4849  18.6646 15.54887163930964")
+        >>> iss = earth.satellite(tle)
+        >>> topos = iss.over_topos(JulianDate(utc=(2015, 2, 27, 22, 22, 0)))
+        >>> topos.latitude
+        <Angle 49deg 19' 48.3">
+        >>> topos.longitude
+        <Angle -155deg 37' 41.8">
+        """
+        return GCRS_to_Topos(self.gcrs(jd).position.km, jd)
 
     def _observe_from_bcrs(self, observer):
         # TODO: what if someone on Mars tries to look at the ISS?


### PR DESCRIPTION
This is the solution to [my question at StackOverflow](http://stackoverflow.com/questions/28707632/getting-latitude-and-longitude-of-the-sun-on-a-world-map-with-pyephem) on how to get the Earth lat/lon position of the Sun (or other bodies) so they can be shown on a world map. It's also meant to fix [pyephem/#16](https://github.com/brandon-rhodes/pyephem/issues/16).

The actual math is straight out of the version of libastro that's bundled in PyEphem.

I did my best to integrate this with Skyfield's classes so I hope I put things in the right place.

Unfortunately, this will only work for Earth. I have no idea how to tweak the magic numbers in the code to work for other bodies.
