### PR TITLE
cache EarthSatellite methods by JulianDate

### DIFF
--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -8,7 +8,7 @@ from sgp4.propagation import sgp4
 from .constants import AU_KM, DAY_S, T0, tau
 from .functions import rot_x, rot_y, rot_z
 from .positionlib import Apparent, Geocentric, ITRF_to_GCRS
-from .timelib import JulianDate, takes_julian_date
+from .timelib import cache_for_julian_date, JulianDate, takes_julian_date
 
 # important ones:
 # jdsatepoch
@@ -27,6 +27,8 @@ class EarthSatellite(object):
 
     def __init__(self, lines, earth):
         sat = twoline2rv(*lines[-2:], whichconst=wgs72)
+        self._cached_jd = None
+        self._cached_jd_values = {}
         self._sgp4_satellite = sat
         self._earth = earth
         self.epoch = JulianDate(utc=(sat.epochyr, 1, sat.epochdays - 1.0))
@@ -76,6 +78,7 @@ class EarthSatellite(object):
         return rGCRS, vGCRS, error
 
     @takes_julian_date
+    @cache_for_julian_date
     def gcrs(self, jd):
         """Return a GCRS position for this Earth satellite.
 

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -49,6 +49,24 @@ extra_documentation = """
 
 """
 
+def cache_for_julian_date(method):
+    """Decorator that can be applied to methods that take a JulianDate
+    as first argument. Will cache method return value for any subsequent
+    calls with the same JulianDate.
+    """
+    def cached_method(self, *args, **kwargs):
+        if self._cached_jd is None or args[0] != self._cached_jd:
+            self._cached_jd = args[0]
+            self._cached_jd_values = {}
+        try:
+            return self._cached_jd_values[method.__name__]
+        except KeyError:
+            return_value = method(self, *args, **kwargs)
+            self._cached_jd_values[method.__name__] = return_value
+            return return_value
+    cached_method.__doc__ = method.__doc__
+    return cached_method
+
 def takes_julian_date(function):
     """Wrap `function` so it accepts the standard Julian date arguments.
 


### PR DESCRIPTION
Sorry for the spam. This is a possible solution for the problem I mentioned in #43: Adding more attributes to EarthSatellites will result in lots of repeated calls to methods like `gcrs()` since the formula behind a particular attribute may depend on other attributes.

For example:

Mean anomaly can be computed from just the jd and "constants" provided by the TLE data. Thus, there is a method called `mean_anomaly(self, jd)`. To compute the eccentric anomaly, I need mean anomaly and eccentricity, resulting in a method like this:

```
def eccentric_anomaly(jd):
    return compute_eccentric_anomaly(self.mean_anomaly(jd), self.eccentricity)
```

Now to get both eccentric anomaly and mean anomaly, a user would need to call these methods like this:

```
m = sat.mean_anomaly(jd)
e = sat.eccentric_anomaly(jd)
```

This is inefficient because the second call will compute mean anomaly again. The problem is compounded because of dependencies like this:
- `time_since_periapsis` depends on `mean_anomaly`
- `time_to_periapsis` depends on `time_since_periapsis`
- `true_anomaly` depends on `eccentric_anomaly`

The decorator implemented here will cache computed results until a different JulianDate is given. This would solve the problem without changing the API (like adding a `compute()` method as I suggested previously, which might also compute more values than the user wanted).

If you agree with this, you should probably merge it before #42 and #43. I can then rebase those so they'll apply cleanly.
