### PR TITLE
Use `is` operator for comparing with `None` (Pep8)

### DIFF
--- a/skyfield/tests/test_keplerian.py
+++ b/skyfield/tests/test_keplerian.py
@@ -34,12 +34,12 @@ def test_instantiate_8077_hoyle():
                             hoyle_8077['mean_anomaly'],
                             hoyle_8077['epoch'])
 
-    assert hoyle != None
+    assert hoyle is not None
 
 def test_instantiate_coordinates():
     coords = ICRCoordinates(x=500.25, y=10.76, z=0.1125)
 
-    assert coords != None
+    assert coords is not None
 
 def test_coordinatesEquivalence():
     coords_the_first = ICRCoordinates(x=500.25, y=10.76, z=0.1125)


### PR DESCRIPTION
I'm trying out the new [Quantified Code](https://www.quantifiedcode.com/) autofixes, and it suggested this change. 