### PR TITLE
Quick fix for the circular import issue

### DIFF
--- a/skyfield/data/hipparcos.py
+++ b/skyfield/data/hipparcos.py
@@ -1,5 +1,4 @@
 import gzip
-from skyfield import api
 from skyfield.functions import to_polar
 from skyfield.starlib import Star
 from skyfield.timelib import T0
@@ -27,6 +26,8 @@ def parse(line):
 
 def load(match_function):
     """Yield the Hipparcos stars for which `match_function(line)` is true."""
+    from skyfield import api
+
     with api.load.open(url) as f:
         for line in gzip.GzipFile(fileobj=f):
             if match_function(line):


### PR DESCRIPTION
This is a quick fix for #97 which is currently preventing skyfield being used.