### PR TITLE
Tests and fixes for issues in Time (delta_t and __repr__)

### DIFF
--- a/skyfield/tests/test_timelib.py
+++ b/skyfield/tests/test_timelib.py
@@ -232,7 +232,7 @@ def test_delta_t(ts):
     # Check future value. Should be calculated by Morrison and
     # Stephenson formula. For 2320 (t=5 cy) should be: -20 + 32 * 5**2
     t = ts.utc(year=2320)
-    assert t.delta_t == -20.0 + (32.0 * 5.0**2)
+    assert abs(t.delta_t + 20.0 - (32.0 * 5.0**2)) < 1.0
  
 def test_time_repr(ts):
 

--- a/skyfield/tests/test_timelib.py
+++ b/skyfield/tests/test_timelib.py
@@ -217,3 +217,28 @@ def test_leap_second(ts):
     assert ts.tai(jd=t3).utc_iso() == '1973-12-31T23:59:60Z'
     assert ts.tai(jd=t4).utc_iso() == '1974-01-01T00:00:00Z'
     assert ts.tai(jd=t5).utc_iso() == '1974-01-01T00:00:01Z'
+
+def test_delta_t(ts):
+
+    # Check delta_t calculation around year 2000/1/1 (from IERS tables this is 63.8285)
+    t = ts.utc(2000, 1, 1, 0, 0, 0)
+    assert abs(t.delta_t - 63.8285) < 1e-5
+
+    # Check historic value. Compare to the table in Morrison and
+    # Stephenson 2004, the tolerance is 2 sigma
+    t = ts.utc(year=1000)
+    assert abs(t.delta_t - 1570.0) < 110.0
+
+    # Check future value. Should be calculated by Morrison and
+    # Stephenson formula. For 2320 (t=5 cy) should be: -20 + 32 * 5**2
+    t = ts.utc(year=2320)
+    assert t.delta_t == -20.0 + (32.0 * 5.0**2)
+ 
+def test_time_repr(ts):
+
+    # Check that repr return is a str (this is required on Python 2,
+    # unicode is not allowed)
+    assert isinstance(repr(ts.utc(year=2000)), str)
+
+    # Check array conversion
+    assert isinstance(repr(ts.utc(year=range(2000, 2010))), str)

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -218,6 +218,10 @@ class Time(object):
         return self.shape[0]
 
     def __repr__(self):
+
+        if getattr(self.tt, 'shape', ()):
+            rstr = '<Time {0} values from tt={1:.6f} to tt={2:.6f}>'
+            return rstr.format(self.tt.size, self.tt.min(), self.tt.max())
         return '<Time tt={0:.6f}>'.format(self.tt)
 
     def __getitem__(self, index):

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -606,11 +606,16 @@ def interpolate_delta_t(delta_t_table, tt):
 
     """
     tt_array, delta_t_array = delta_t_table
-    delta_t = interp(tt, tt_array, delta_t_array, nan, nan)
+    delta_t = _to_array(interp(tt, tt_array, delta_t_array, nan, nan))
     missing = isnan(delta_t)
+
     if missing.any():
-        tt = tt[missing]
-        delta_t[missing] = delta_t_formula_morrison_and_stephenson_2004(tt)
+        # Test if we are dealing with an array and proceed appropriately
+        if missing.shape:
+            tt = tt[missing]
+            delta_t[missing] = delta_t_formula_morrison_and_stephenson_2004(tt)
+        else:
+            delta_t = delta_t_formula_morrison_and_stephenson_2004(tt)
     return delta_t
 
 def delta_t_formula_morrison_and_stephenson_2004(tt):


### PR DESCRIPTION
This pull request contains a few short tests that cover the issues I've been finding with Time (#98 and #99).

It also contains fixes for them:
- For #98 I've added a branch that deals with filling in missing values of delta_t correctly for scalar inputs.
- For #99 I've added a branch to `__repr__` that produces output for the array valued case. It takes it cues from how `skyfield.units.Angle` outputs, giving the number of values and the range.

Hope it's of some use!