### PR TITLE
Fix for calendar_tuple

### DIFF
--- a/skyfield/tests/test_timelib.py
+++ b/skyfield/tests/test_timelib.py
@@ -246,6 +246,8 @@ def test_time_repr(ts):
 
 def test_jd_calendar():
 
+    import numbers
+
     # Check a specific instance (using UNIX epoch here, though that's
     # an arbitrary choice)
     jd_unix = 2440587.5
@@ -257,12 +259,12 @@ def test_jd_calendar():
     assert cal == cal_unix
 
     # Check that all the return types are correct
-    assert isinstance(cal[0], int)  # Year
-    assert isinstance(cal[1], int)  # Month
-    assert isinstance(cal[2], int)  # Day
-    assert isinstance(cal[3], int)  # Hour
-    assert isinstance(cal[4], int)  # Minute
-    assert isinstance(cal[5], float)  # Second
+    assert isinstance(cal[0], numbers.Integral)  # Year
+    assert isinstance(cal[1], numbers.Integral)  # Month
+    assert isinstance(cal[2], numbers.Integral)  # Day
+    assert isinstance(cal[3], numbers.Integral)  # Hour
+    assert isinstance(cal[4], numbers.Integral)  # Minute
+    assert isinstance(cal[5], numbers.Real)  # Second
 
     # Check backward conversion
     assert julian_date(*cal) == jd_unix

--- a/skyfield/tests/test_timelib.py
+++ b/skyfield/tests/test_timelib.py
@@ -3,7 +3,7 @@ from assay import assert_raises
 from pytz import timezone
 from skyfield import api
 from skyfield.constants import DAY_S
-from skyfield.timelib import utc
+from skyfield.timelib import utc, calendar_tuple, julian_date
 from datetime import datetime
 
 one_second = 1.0 / DAY_S
@@ -218,6 +218,7 @@ def test_leap_second(ts):
     assert ts.tai(jd=t4).utc_iso() == '1974-01-01T00:00:00Z'
     assert ts.tai(jd=t5).utc_iso() == '1974-01-01T00:00:01Z'
 
+
 def test_delta_t(ts):
 
     # Check delta_t calculation around year 2000/1/1 (from IERS tables this is 63.8285)
@@ -242,3 +243,40 @@ def test_time_repr(ts):
 
     # Check array conversion
     assert isinstance(repr(ts.utc(year=range(2000, 2010))), str)
+
+def test_jd_calendar():
+
+    # Check a specific instance (using UNIX epoch here, though that's
+    # an arbitrary choice)
+    jd_unix = 2440587.5
+    cal_unix = (1970, 1, 1, 0, 0, 0.0)
+
+    cal = calendar_tuple(jd_unix)
+
+    # Check that the returned value is correct
+    assert cal == cal_unix
+
+    # Check that all the return types are correct
+    assert isinstance(cal[0], int)  # Year
+    assert isinstance(cal[1], int)  # Month
+    assert isinstance(cal[2], int)  # Day
+    assert isinstance(cal[3], int)  # Hour
+    assert isinstance(cal[4], int)  # Minute
+    assert isinstance(cal[5], float)  # Second
+
+    # Check backward conversion
+    assert julian_date(*cal) == jd_unix
+
+    # Check array conversion components
+    jd_array = jd_unix + np.arange(5.0)
+    cal_array = calendar_tuple(jd_array)
+    
+    assert (cal_array[0] == 1970).all()
+    assert (cal_array[1] == 1).all()
+    assert (cal_array[2] == np.arange(1, 6)).all()
+    assert (cal_array[3] == 0).all()
+    assert (cal_array[4] == 0).all()
+    assert (cal_array[5] == 0.0).all()
+
+    # Check reversal of array
+    assert (julian_date(*cal_array) == jd_array).all()

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -571,8 +571,9 @@ def calendar_tuple(jd_float, offset=0.0):
     throw away the seconds; and so forth.
 
     """
+    jd_float = _to_array(jd_float)
     whole, fraction = divmod(jd_float + 0.5, 1.0)
-    whole = whole.astype(whole)
+    whole = whole.astype(int)
     year, month, day = calendar_date(whole)
     hour, hfrac = divmod(fraction * 24.0, 1.0)
     minute, second = divmod(hfrac * 3600.0, 60.0)


### PR DESCRIPTION
This pull request is a fix for #102.

I've also added some unit tests to check the conversion of calendar_tuple/julian_date, and wrapped the input of calendar_tuple in a `_to_array` call to stop it failing if called with a Python scalar argument.