### PR TITLE
Issue #116: EarthSatellite now caches the timescale 

### DIFF
--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -24,15 +24,18 @@ _minutes_per_day = 1440.
 
 class EarthSatellite(object):
     """An Earth satellite loaded from a TLE file and propagated with SGP4."""
+    
+    # cache for timescale
+    timescale = None
 
     def __init__(self, lines, earth):
         sat = twoline2rv(*lines[-2:], whichconst=wgs72)
         self._sgp4_satellite = sat
         self._earth = earth
-        # TODO: Drat. Where should this Timescale come from?
-        # Should they have to pass it in?
-        from skyfield import api
-        self.epoch = api.load.timescale().utc(sat.epochyr, 1, sat.epochdays)
+        if EarthSatellite.timescale is None:
+            from skyfield import api
+            EarthSatellite.timescale = api.load.timescale()
+        self.epoch = EarthSatellite.timescale.utc(sat.epochyr, 1, sat.epochdays)
 
     def __repr__(self):
         sat = self._sgp4_satellite


### PR DESCRIPTION
`EarthSatellite.__init__()` now caches the timescale as a class variable Instead of loading it each time.

This increases the speed of the initialization by ~100x (from ~20 ms to ~0.23 ms), which is relevant when loading complete satellite catalogs (3 minutes to 2 seconds).

This is 20x slower than pyephem, but fast enough that the speed difference is usually not relevant.

This is the fix to issue #116 .  If the same code is in the stand-alone sgp4 library it should be propagated there as well.