### PR TITLE
Feature/load nameless tle

### DIFF
--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -361,7 +361,7 @@ def parse_celestrak_tle(fileobj):
         else:  # two-line element set, no name provided!
             line1 = line.decode('ascii')
             line2 = next(lines).decode('ascii')
-            name = line1.split()[1][:-1]  # grab satellite ID# as name
+            name = line2.split()[1]  # grab satellite ID# as name
         sat = EarthSatellite(line1, line2, name)
         yield name, sat
         if ' (' in name:

--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -188,10 +188,14 @@ class Loader(object):
     def tle(self, url, reload=False):
         """Load and parse a satellite TLE file.
 
-        Given a URL or a local path, this loads a file of three-line
-        records in the common Celestrak file format, where each first
-        line gives the name of a satellite and the following two lines
-        are the TLE orbital elements.
+        Given a URL or a local path, this loads a file of two- or three-line
+        records in the common Celestrak file format. For a three-line element
+        set, each first line gives the name of a satellite and the following
+        two lines are the TLE orbital elements. A two-line element set
+        comprises only these last two lines.
+
+        If two-line element sets are provided, the EarthSatellite 'name'
+        attribute is set to the satellite ID number for the object.
 
         Returns a Python dictionary whose keys are satellite names and
         values are :class:`~skyfield.sgp4lib.EarthSatellite` objects.

--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -362,11 +362,12 @@ def parse_celestrak_tle(fileobj):
             name = line.decode('ascii').strip()
             line1 = next(lines).decode('ascii')
             line2 = next(lines).decode('ascii')
+            sat = EarthSatellite(line1, line2, name)
         else:  # two-line element set, no name provided!
             line1 = line.decode('ascii')
             line2 = next(lines).decode('ascii')
-            name = line2.split()[1]  # grab satellite ID# as name
-        sat = EarthSatellite(line1, line2, name)
+            sat = EarthSatellite(line1, line2, name=None)
+            sat.name = str(sat.model.satnum)  # set to satellite number
         yield sat.model.satnum, sat
         yield name, sat
         if ' (' in name:

--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -358,16 +358,17 @@ def parse_leap_seconds(fileobj):
 def parse_celestrak_tle(fileobj):
     lines = iter(fileobj)
     for line in lines:
-        if line.decode('ascii').strip()[0] == '0':
+        if line.decode('ascii').strip()[0] != '1':  # three-line elset
             name = line.decode('ascii').strip()
             line1 = next(lines).decode('ascii')
             line2 = next(lines).decode('ascii')
             sat = EarthSatellite(line1, line2, name)
-        else:  # two-line element set, no name provided!
+        else:  # two-line elset, no name provided!
             line1 = line.decode('ascii')
             line2 = next(lines).decode('ascii')
             sat = EarthSatellite(line1, line2, name=None)
-            sat.name = str(sat.model.satnum)  # set to satellite number
+            name = str(sat.model.satnum)  # set to satellite number
+            sat.name = name
         yield sat.model.satnum, sat
         yield name, sat
         if ' (' in name:

--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import itertools
 import os
+import errno
 import numpy as np
 import sys
 from datetime import date, datetime, timedelta
@@ -79,8 +80,11 @@ class Loader(object):
         self.verbose = verbose
         self.expire = expire
         self.events = []
-        if not os.path.exists(self.directory):
+        try:
             os.makedirs(self.directory)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
         # Each instance gets its own copy of these data structures,
         # instead of sharing a single copy, so users can edit them

--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -354,9 +354,14 @@ def parse_leap_seconds(fileobj):
 def parse_celestrak_tle(fileobj):
     lines = iter(fileobj)
     for line in lines:
-        name = line.decode('ascii').strip()
-        line1 = next(lines).decode('ascii')
-        line2 = next(lines).decode('ascii')
+        if line.decode('ascii').strip()[0] == '0':
+            name = line.decode('ascii').strip()
+            line1 = next(lines).decode('ascii')
+            line2 = next(lines).decode('ascii')
+        else:  # two-line element set, no name provided!
+            line1 = line.decode('ascii')
+            line2 = next(lines).decode('ascii')
+            name = line1.split()[1][:-1]  # grab satellite ID# as name
         sat = EarthSatellite(line1, line2, name)
         yield name, sat
         if ' (' in name:

--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -188,11 +188,11 @@ class Loader(object):
     def tle(self, url, reload=False):
         """Load and parse a satellite TLE file.
 
-        Given a URL or a local path, this loads a file of two- or three-line
-        records in the common Celestrak file format. For a three-line element
-        set, each first line gives the name of a satellite and the following
-        two lines are the TLE orbital elements. A two-line element set
-        comprises only these last two lines.
+        Given a URL or a local path, this loads a file of three-line records in
+        the common Celestrak file format, or two-line records like those from
+        space-track.org. For a three-line element set, each first line gives
+        the name of a satellite and the following two lines are the TLE orbital
+        elements. A two-line element set comprises only these last two lines.
 
         If two-line element sets are provided, the EarthSatellite 'name'
         attribute is set to the satellite ID number for the object.

--- a/skyfield/tests/test_io_parsing.py
+++ b/skyfield/tests/test_io_parsing.py
@@ -31,4 +31,10 @@ def test_spacetrack():
     f = BytesIO(sample_spacetrack_text)
     d = dict(parse_celestrak_tle(f))
     assert len(d) == 4
+    assert d['29273'] is d[29273]
+    assert d['29274'] is d[29274]
     assert d[29273] is not d[29274]
+    assert d[29273].model.satnum == 29273
+    assert d[29273].name == '29273'
+    assert d[29274].model.satnum == 29274
+    assert d[29274].name == '29274'

--- a/skyfield/tests/test_io_parsing.py
+++ b/skyfield/tests/test_io_parsing.py
@@ -30,5 +30,5 @@ def test_celestrak():
 def test_spacetrack():
     f = BytesIO(sample_spacetrack_text)
     d = dict(parse_celestrak_tle(f))
-    assert len(d) == 6
+    assert len(d) == 4
     assert d[29273] is not d[29274]

--- a/skyfield/tests/test_io_parsing.py
+++ b/skyfield/tests/test_io_parsing.py
@@ -12,6 +12,13 @@ FLOCK 2E-1              \n\
 2 41483  51.6270 103.3896 0004826  61.7810 298.3684 15.92672255114129
 """
 
+sample_spacetrack_text = b"""\
+1 29273U 06033B   18081.29838594 -.00000056 +00000-0 +00000-0 0  9993
+2 29273 000.0189 154.5198 0004980 202.4902 284.9321 01.00271755042548
+1 29274U 06033C   18081.39999693 +.00002637 +00000-0 +10299-2 0  9992
+2 29274 005.9144 244.7152 6177908 248.3941 037.5897 03.74556424124616
+"""
+
 def test_celestrak():
     f = BytesIO(sample_celestrak_text)
     d = dict(parse_celestrak_tle(f))
@@ -19,3 +26,9 @@ def test_celestrak():
     assert d[25544] is d['ISS'] is d['ISS (ZARYA)'] is d['ZARYA']
     assert d[41483] is d['FLOCK 2E-1']
     assert d[25544] is not d[41483]
+
+def test_spacetrack():
+    f = BytesIO(sample_spacetrack_text)
+    d = dict(parse_celestrak_tle(f))
+    assert len(d) == 6
+    assert d[29273] is not d[29274]


### PR DESCRIPTION
Added the ability to load a nameless TLE using `load.tle()` from the API package. For example, this allows us to load:

```
1 00005U 58002B   18130.23524677  .00000070  00000-0  10021-3 0  9993
2 00005  34.2455  77.6488 1845867 131.1918 246.3184 10.84813857121819
```

rather than:

```
0 VANGUARD 1
1 00005U 58002B   18130.23524677  .00000070  00000-0  10021-3 0  9993
2 00005  34.2455  77.6488 1845867 131.1918 246.3184 10.84813857121819
```

The resulting `EarthSatellite` object will then have the `name` field set to the satellite ID number, in this case `'00005'` without the classification letter at the end.

I also improved the check/make directory logic in the `Loader` to be more robust to possible race conditions/access from multiple sources.