### PR TITLE
Python 2 builtin intern() was moved to sys.intern() in Python 3

### DIFF
--- a/media/logo.py
+++ b/media/logo.py
@@ -16,6 +16,10 @@
 
 from math import cos, pi, sin
 try:
+    intern         # Python 2
+except NameError:  # Python 3
+    from sys import intern
+try:
     from reportlab.pdfgen.canvas import Canvas
     from reportlab.pdfbase import pdfmetrics
     from reportlab.pdfbase.ttfonts import TTFont


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/builtins.html#moved-intern

[flake8](http://flake8.pycqa.org) testing of https://github.com/skyfielders/python-skyfield on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./media/logo.py:53:22: F821 undefined name 'intern'
            letter = intern(line[8:11])
                     ^
1     F821 undefined name 'intern'
1
```