### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
   - "python setup.py sdist"


### PR DESCRIPTION
Add Python 3.7 to the testing In alignment with travis-ci/travis-ci#9069