### PR TITLE
Fix reference_frames keyword in elementslib

### DIFF
--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -44,11 +44,9 @@ class OsculatingElements(object):
         The times of the position and velocity vectors
     mu_km_s: float
         Gravitational parameter (G*M) in units of km^3/s^2
-    ref_frame : 3x3 array
-        Rotation matrix from ICRF to reference frame of the elements
 
     """
-    def __init__(self, position, velocity, time, mu_km_s, ref_frame=None):
+    def __init__(self, position, velocity, time, mu_km_s):
         self._pos_vec = position.km
         self._vel_vec = velocity.km_per_s
         self.time = time
@@ -58,8 +56,6 @@ class OsculatingElements(object):
         self._e_vec = eccentricity_vector(self._pos_vec, self._vel_vec, self._mu)
         self._n_vec = node_vector(self._h_vec)
 
-
-        self._ref_frame = ref_frame
 
     @reify
     def apoapsis_distance(self):

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -58,8 +58,6 @@ class OsculatingElements(object):
         self._e_vec = eccentricity_vector(self._pos_vec, self._vel_vec, self._mu)
         self._n_vec = node_vector(self._h_vec)
 
-        self.size = position.km[0].size
-        self.shape = position.km[0].shape
 
         self._ref_frame = ref_frame
 

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -3,7 +3,7 @@
 from .functions import dots, length_of, angle_between
 from .constants import DAY_S, tau
 from .data.gravitational_parameters import GM_dict
-from .units import Distance, Angle
+from .units import Distance, Angle, Velocity
 from .descriptorlib import reify
 from numpy import (array, arctan2, sin, arctan, tan, inf, repeat, float64,
                    sinh, sqrt, arccos, arctanh, zeros_like, ones_like, divide,
@@ -20,13 +20,19 @@ def osculating_elements_of(position, reference_frame=None):
 
     """
     mu = GM_dict.get(position.center, 0) + GM_dict.get(position.target, 0)
-    return OsculatingElements(
-        position.position,
-        position.velocity,
-        position.t,
-        mu,
-        reference_frame,
-    )
+    
+    if reference_frame is not None:
+        position_vec = Distance(reference_frame.dot(position.position.au))
+        velocity_vec = Velocity(reference_frame.dot(position.velocity.au_per_d))
+    else:
+        position_vec = position.position
+        velocity_vec = position.velocity
+        
+    return OsculatingElements(position_vec,
+                              velocity_vec,
+                              position.t,
+                              mu)
+
 
 class OsculatingElements(object):
     """
@@ -55,7 +61,6 @@ class OsculatingElements(object):
         self._h_vec = cross(self._pos_vec, self._vel_vec, 0, 0).T
         self._e_vec = eccentricity_vector(self._pos_vec, self._vel_vec, self._mu)
         self._n_vec = node_vector(self._h_vec)
-
 
     @reify
     def apoapsis_distance(self):

--- a/skyfield/tests/test_elementslib.py
+++ b/skyfield/tests/test_elementslib.py
@@ -258,7 +258,7 @@ def test_equatorial_au_d(ts):
     compare(calc_data, horizons_data, epsilon)
 
 
-def BROKEN_test_ecliptic_km_d(ts):
+def test_ecliptic_km_d(ts):
     """Tests against data from Horizons in km and days, with ecliptic reference plane
     """
     geocentric_pos = (moon - earth).at(ts.tdb(2015, 3, 2, 2))
@@ -279,7 +279,7 @@ def BROKEN_test_ecliptic_km_d(ts):
     compare(calc_data, horizons_data, epsilon)
 
 
-def BROKEN_test_ecliptic_km_s(ts):
+def test_ecliptic_km_s(ts):
     """Tests against data from Horizons in km and seconds, with ecliptic reference plane
     """
     geocentric_pos = (moon - earth).at(ts.tdb(2015, 3, 2, 2))
@@ -300,7 +300,7 @@ def BROKEN_test_ecliptic_km_s(ts):
     compare(calc_data, horizons_data, epsilon)
 
 
-def BROKEN_test_ecliptic_au_d(ts):
+def test_ecliptic_au_d(ts):
     """Tests against data from Horizons in au and days, with ecliptic reference plane
     """
     geocentric_pos = (moon - earth).at(ts.tdb(2015, 3, 2, 2))


### PR DESCRIPTION
Fixes the reference_frame keyword of `osculating_elements_of`, which currently isn't working. This also makes the rest of the tests (currently marked broken) pass.