### PR TITLE
Fix osculating elements repr

### DIFF
--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -176,7 +176,7 @@ class OsculatingElements(object):
         return Angle(radians=l)
 
     def __repr__(self):
-        return '<Elements {} sets>'.format(self.size)
+        return '<Elements {} sets>'.format(self.time.tt.size)
 
 # a = semi-major axis
 # b = semi-minor axis

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -176,7 +176,7 @@ class OsculatingElements(object):
         return Angle(radians=l)
 
     def __repr__(self):
-        return '<Elements {} sets>'.format(self.time.tt.size)
+        return '<Elements {0} sets>'.format(self.time.tt.size)
 
 # a = semi-major axis
 # b = semi-minor axis

--- a/skyfield/tests/test_elementslib.py
+++ b/skyfield/tests/test_elementslib.py
@@ -180,6 +180,11 @@ def horizons_array(elem, units='km_d', ):
     return array_
 
 
+def test_repr(ts):
+    elements = osculating_elements_of((moon-earth).at(ts.utc(2015, 3, 2, 12)))
+    assert repr(elements) == '<Elements 1 sets>'
+
+
 def test_single_time(ts):
     """Tests creation of an OsculatingElements object with a single set of elements
     """


### PR DESCRIPTION
The repr still used OsculatingElements.size which was removed, this PR fixes that, and adds a test to make sure the repr is working as expected.