### PR TITLE
Revert filename change if download fails

### DIFF
--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -182,7 +182,18 @@ class Loader(object):
                              .format(filename))
 
         self._log('  Downloading: {0}', url)
-        download(url, path, self.verbose)
+        try:
+            download(url, path, self.verbose)
+        except OSError as download_err:
+            self._log('  Failed to download')
+            # If we made a backup revert the name change.
+            try:
+                os.rename(self.path_to(backup_name), self.path_to(filename))
+                self._log('  The backup was restored')
+            except:
+                self._log('  Backup not restored')
+                pass
+            raise download_err
 
         if parser is not None:
             self._log('  Parsing with: {0}()', parser.__name__)


### PR DESCRIPTION
In previous changes (see Issue #105) support was added to run Skyfield offline by creating a Loader which does not check file expiry dates. Some use cases (like mine, which is a portable satellite tracker) has intermittent internet access (and/or servers can be down). Therefore it is desirable to enable users to attempt the download, but use old files if this fails. I.e:

```
try:
    ts = skyfield.api.Loader('some_directory').timescale()
except OSError:
    ts = skyfield.api.Loader('some_directory', expire=False).timescale()
```

However, the current version of Skyfield will rename any existing files to 'filename.old' before attempting downloading, and not revert this. This pull request simply adds reverting to the old filename to make the above usecase possible.

Specifically:
Old behaviour: When an expired file is found it is renamed to 'file.oldX' and a download attempt is made. If this fails the program exits with an OSError.
New behaviour: If said download fails the file is renamed again to its old name. The program then exits with an OSError.