### PR TITLE
Check if mu is zero in OsculatingElements.__init__()

### DIFF
--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -53,6 +53,8 @@ class OsculatingElements(object):
 
     """
     def __init__(self, position, velocity, time, mu_km_s):
+        if mu_km_s == 0: raise ValueError('`mu_km_s` is zero')
+        
         self._pos_vec = position.km
         self._vel_vec = velocity.km_per_s
         self.time = time

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -53,7 +53,9 @@ class OsculatingElements(object):
 
     """
     def __init__(self, position, velocity, time, mu_km_s):
-        if mu_km_s == 0: raise ValueError('`mu_km_s` is zero')
+        if mu_km_s == 0: 
+            raise ValueError('`mu_km_s`, which represents the gravity between '
+                             'the orbiting and orbited bodies cannot be zero')
         
         self._pos_vec = position.km
         self._vel_vec = velocity.km_per_s

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -53,9 +53,9 @@ class OsculatingElements(object):
 
     """
     def __init__(self, position, velocity, time, mu_km_s):
-        if mu_km_s == 0: 
-            raise ValueError('`mu_km_s`, which represents the gravity between '
-                             'the orbiting and orbited bodies cannot be zero')
+        if mu_km_s <= 0: 
+            raise ValueError('`mu_km_s` (the standard gravitational parameter '
+                             'in km^3/s^2) must be positive and non-zero')
         
         self._pos_vec = position.km
         self._vel_vec = velocity.km_per_s


### PR DESCRIPTION
Raises a ValueError instead of having a mysterious numpy divide by zero warning later on