### PR TITLE
Make EarthSatellite target attribute the NAIF id

### DIFF
--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -92,7 +92,7 @@ class EarthSatellite(VectorFunction):
         self.model = sat
         self.epoch = ts.utc(sat.epochyr, 1, sat.epochdays)
 
-        self.target = -100_000 - self.model.satnum
+        self.target = -100000 - self.model.satnum
         self.target_name = 'Satellite{0} {1}'.format(
             self.model.satnum,
             ' ' + repr(self.name) if self.name else '',

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -92,7 +92,7 @@ class EarthSatellite(VectorFunction):
         self.model = sat
         self.epoch = ts.utc(sat.epochyr, 1, sat.epochdays)
 
-        self.target = object()  # TODO: make this more interesting
+        self.target = -100_000 - self.model.satnum
         self.target_name = 'Satellite{0} {1}'.format(
             self.model.satnum,
             ' ' + repr(self.name) if self.name else '',

--- a/skyfield/tests/test_earth_satellites.py
+++ b/skyfield/tests/test_earth_satellites.py
@@ -126,3 +126,7 @@ def test_epoch_date():
     lines = s.splitlines()
     sat = EarthSatellite(lines[1], lines[2], lines[0])
     assert sat.epoch.utc_jpl() == 'A.D. 1998-Jan-01 00:00:00.0000 UT'
+    
+def test_target_number():
+    s = EarthSatellite(*iss_tle0.splitlines())
+    assert s.target == -125544


### PR DESCRIPTION
According to the [SPICE toolkit documentation](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/naif_ids.html#Earth%20Orbiting%20Spacecraft.):

>If an Earth orbiting spacecraft lacks a DSN identification code, the NAIF ID is derived from the tracking ID assigned to it by NORAD via:
>
>      NAIF ID = -100000 - NORAD ID code
>
>For example, NORAD assigned the code 15427 to the NOAA 9 spacecraft. This code corresponds to the NAIF ID -115427.

I confirmed that the satellite numbers in TLEs are the NORAD ID code by checking in [this file from celestrak](https://celestrak.com/NORAD/elements/noaa.txt) that the satellite number for NOAA 9 is in fact 15427.

I wasn't sure if you would want a test or not, so I included one just in case.