### PR TITLE
Sgp4lib update/7 dec 15 vallado version

### DIFF
--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -458,11 +458,11 @@ def parse_tle(fileobj):
             b2.startswith(b'2 ') and len(b2) >= 69):
 
             b0 = b0.rstrip(b'\n\r')
-            if len(b0) == 24:   # Celestrak
-                name = b0.decode('ascii').rstrip()
-                names = [name]
-            elif b0.startswith(b'0 '): # Spacetrack 3-line format
+            if b0.startswith(b'0 '): # Spacetrack 3-line format
                 name = b0[2:].decode('ascii').rstrip()
+                names = [name]
+            elif ((not b0.startswith(b'1 ')) and (not b0.startswith(b'2 '))): # Celestrak and others
+                name = b0.decode('ascii').rstrip()
                 names = [name]
             else:
                 name = None

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -48,6 +48,8 @@ class EarthSatellite(VectorFunction):
     ``epoch``
         A Skyfield :class:`~skyfield.timelib.Time` giving the exact
         epoch moment for these satellite orbit parameters.
+    ``name``
+        Satellite name
 
     If you are interested in the catalog entry details, the SGP4 model
     parameters for a particular satellite can be accessed through its
@@ -55,6 +57,10 @@ class EarthSatellite(VectorFunction):
 
     ``model.satnum``
         The unique satellite NORAD catalog number given in the TLE file.
+    ``model.classification``
+        Satellite classification or `U`
+    ``model.intldesg``
+        International designator
     ``model.epochyr``
         Full four-digit year of this element set's epoch moment.
     ``model.epochdays``
@@ -67,6 +73,10 @@ class EarthSatellite(VectorFunction):
         Second time derivative of the mean motion (ignored by SGP4).
     ``model.bstar``
         Ballistic drag coefficient B* in inverse earth radii.
+    ``model.ephtype``
+        Ephemeris type (ignored by SGP4 as determination now automatic)
+    ``model.elnum``
+        Element number
     ``model.inclo``
         Inclination in radians.
     ``model.nodeo``
@@ -77,8 +87,10 @@ class EarthSatellite(VectorFunction):
         Argument of perigee in radians.
     ``model.mo``
         Mean anomaly in radians.
-    ``model.no``
+    ``model.no_kozai``
         Mean motion in radians per minute.
+    ``model.revnum``
+        Revolution number at epoch [Revs]
 
     """
     center = 399


### PR DESCRIPTION
Bring current with python-sgp4 [pull request 35.](https://github.com/brandon-rhodes/python-sgp4/pull/35)

Documentation update to reflect change from model.no to model.no_kozai, 
as well as expose all other model variables available from the TLE.