### PR TITLE
Satellite events almanac functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ install:
   - "pip install $(echo ../dist/skyfield-*.tar.gz)'[tests]'"
   - "pip install pyflakes"
   - "pip install https://github.com/brandon-rhodes/assay/archive/master.zip"
-  - "if [[ $TRAVIS_PYTHON_VERSION < 3.7 ]] ; then pip install numpy==1.11.3 pandas==0.23.4 unittest2 ; else pip install pandas ; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION < 3.7 ]] ; then pip install numpy==1.11.3 scipy==1.2.2 pandas==0.23.4 unittest2 ; else pip install pandas ; fi"
   - "python -c 'import pandas'"
 
 script:
   - "../test-code.sh"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]] ; then pip install astropy==3.0.1 matplotlib==2.2.3 numpy==1.14.2 sphinx==1.7.2 ; cd .. ; ./test-docs.sh ; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]] ; then pip install astropy==3.0.1 matplotlib==2.2.3 numpy==1.14.2 scipy=1.2.2 sphinx==1.7.2 ; cd .. ; ./test-docs.sh ; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
 
 script:
   - "../test-code.sh"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]] ; then pip install astropy==3.0.1 matplotlib==2.2.3 numpy==1.14.2 scipy=1.2.2 sphinx==1.7.2 ; cd .. ; ./test-docs.sh ; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]] ; then pip install astropy==3.0.1 matplotlib==2.2.3 numpy==1.14.2 scipy==1.2.2 sphinx==1.7.2 ; cd .. ; ./test-docs.sh ; fi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ beautifulsoup4==4.6.0
 html5lib==1.0.1
 lxml==4.4.1
 mock==2.0.0
-numpy==1.17.2
+numpy==1.14.2
 matplotlib==2.2.2
 pandas==0.23.3
 pyflakes==2.1.1
 python-dateutil>=2.5.0
 pytz
-scipy==1.3.2
+scipy
 sphinx==1.7.2
 https://github.com/brandon-rhodes/assay/archive/master.zip
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ beautifulsoup4==4.6.0
 html5lib==1.0.1
 lxml==4.4.1
 mock==2.0.0
-numpy==1.14.2
+numpy==1.17.2
 matplotlib==2.2.2
 pandas==0.23.3
 pyflakes==2.1.1
 python-dateutil>=2.5.0
 pytz
-scipy
+scipy==1.3.2
 sphinx==1.7.2
 https://github.com/brandon-rhodes/assay/archive/master.zip
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pandas==0.23.3
 pyflakes==2.1.1
 python-dateutil>=2.5.0
 pytz
+scipy
 sphinx==1.7.2
 https://github.com/brandon-rhodes/assay/archive/master.zip
 -e .

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'jplephem>=2.11',
         'numpy',
+        'scipy',
         'sgp4>=1.4',
         ],
     extras_require=extras,          # support "pip install skyfield[tests]"

--- a/skyfield/almanac.py
+++ b/skyfield/almanac.py
@@ -439,7 +439,7 @@ def find_satellite_events(start_time, end_time,
     stepsize = 1 / (stepsperrev * (1 + revolutions_per_day))
     # Extend the timerange by one step on each end to find transitions
     jds = [t.tai + pad for t, pad in zip((start_time, end_time), (-stepsize, stepsize))]
-    nsteps = ceil((jds[1] - jds[0]) / stepsize)
+    nsteps = int(ceil((jds[1] - jds[0]) / stepsize))
     endpoints = [start_time.ts.tai(jd=jd) for jd in jds]
     times = linspace_time(*endpoints, num=nsteps)
     timesjd = times.tai

--- a/skyfield/almanac.py
+++ b/skyfield/almanac.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Routines to solve for circumstances like sunrise, sunset, and moon phase."""
 
 from numpy import (cos, diff, flatnonzero, linspace, multiply, sign,

--- a/skyfield/almanac.py
+++ b/skyfield/almanac.py
@@ -380,7 +380,7 @@ def satellite_altitude(satellite, topos, time, timescale=None, and_azdist=False)
 def linspace_time(start_time: Time, stop_time: Time, *, num=50, step=None, endpoint=True):
 """
 
-def linspace_time(start_time, stop_time, *, num=50, step=None, endpoint=True):
+def linspace_time(start_time, stop_time, num=50, step=None, endpoint=True):
     """
     Return an evenly-spaced array of skyfield.Time
 

--- a/skyfield/almanac.py
+++ b/skyfield/almanac.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Routines to solve for circumstances like sunrise, sunset, and moon phase."""
 
+from __future__ import print_function, division
+
 from numpy import (cos, diff, flatnonzero, linspace, multiply, sign,
                    zeros_like, pi, arange, ceil, argwhere)
 from scipy import optimize

--- a/skyfield/documentation/almanac.rst
+++ b/skyfield/documentation/almanac.rst
@@ -240,6 +240,50 @@ of the phases of twilight using integers:
     1 2019-11-08T23:25:34Z
     0 2019-11-08T23:57:44Z
 
+Satellite Events
+================
+
+The times when a satellite rises, culminates, and sets
+are based on the satellite, a location, and the horizon elevation.
+
+.. testcode::
+
+    satellite = api.EarthSatellite(
+            "1 25544U 98067A   20012.52707367  .00016717  00000-0  10270-3 0  9043",
+            "2 25544  51.6437  43.6359 0004998 123.7741 236.3886 15.49565134  7728",
+            name="Zarya")
+    bluffton = api.Topos('40.8939 N', '83.8917 W')
+    t0 = ts.utc(2020, 1, 15, 0)
+    t1 = ts.utc(2020, 1, 16, 0)
+    t, y = almanac.find_satellite_events(t0, t1,
+                satellite=satellite, topos=bluffton, horizon=10)
+    altitude, azimuth, distance = almanac.satellite_altitude(
+                satellite=satellite, topos=bluffton, time=t, and_azdist=True)
+
+    for ti, yi, alti, azi in zip(t, y, altitude.degrees, azimuth.degrees):
+        print("%1d. %-9s %s alt=%2d az=%3.0f deg" %
+                (yi, almanac.SATELLITE_EVENTS[yi], ti.utc_iso(' '), round(alti), round(azi)))
+
+.. testoutput::
+
+    0. rise      2020-01-15 02:44:35Z alt=10 az=228 deg
+    1. culminate 2020-01-15 02:47:55Z alt=78 az=142 deg
+    2. set       2020-01-15 02:51:17Z alt=10 az= 56 deg
+    0. rise      2020-01-15 04:22:23Z alt=10 az=289 deg
+    1. culminate 2020-01-15 04:25:01Z alt=21 az=340 deg
+    2. set       2020-01-15 04:27:39Z alt=10 az= 32 deg
+    0. rise      2020-01-15 06:01:04Z alt=10 az=330 deg
+    1. culminate 2020-01-15 06:02:45Z alt=13 az=  1 deg
+    2. set       2020-01-15 06:04:26Z alt=10 az= 31 deg
+    0. rise      2020-01-15 07:37:45Z alt=10 az=327 deg
+    1. culminate 2020-01-15 07:40:27Z alt=22 az= 21 deg
+    2. set       2020-01-15 07:43:10Z alt=10 az= 75 deg
+    0. rise      2020-01-15 09:14:10Z alt=10 az=302 deg
+    1. culminate 2020-01-15 09:17:29Z alt=67 az=219 deg
+    2. set       2020-01-15 09:20:48Z alt=10 az=136 deg
+
+
+
 Solar terms
 ===========
 

--- a/skyfield/tests/test_satellite_almanac.py
+++ b/skyfield/tests/test_satellite_almanac.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division
 from skyfield import api, almanac
 
 def test_sat_almanac_LEO():

--- a/skyfield/tests/test_satellite_almanac.py
+++ b/skyfield/tests/test_satellite_almanac.py
@@ -1,0 +1,110 @@
+from __future__ import print_function
+from skyfield import api, almanac
+
+def test_sat_almanac_LEO():
+    # Testcase from
+    # https://github.com/skyfielders/astronomy-notebooks/blob/master/Solvers/Earth-Satellite-Passes.ipynb
+    # with elevated horizon
+
+    tle = ["TIANGONG 1",
+           "1 37820U 11053A   14314.79851609  .00064249  00000-0  44961-3 0  5637",
+           "2 37820  42.7687 147.7173 0010686 283.6368 148.1694 15.73279710179072"]
+    sat = api.EarthSatellite(*tle[1:3], name=tle[0])
+    topos = api.Topos('42.3581 N', '71.0636 W')
+    timescale = api.load.timescale()
+    t0 = timescale.tai(2014, 11, 10)
+    t1 = timescale.tai(2014, 11, 11)
+    horizon = 20
+    nexpected = 12
+
+    times, yis = almanac.find_satellite_events(t0, t1, sat, topos, horizon=20)
+    assert(verify_sat_almanac(times, yis, sat, topos, horizon, nexpected))
+
+
+def test_sat_almanac_Tricky():
+    # Various tricky satellites
+    # Integral: 3 days high eccentricity.
+    # ANIK-F1R  Geo always visible from Boston
+    # PALAPA D  Geo never visible from Boston
+    # Ariane 5B GTO
+    # Swift Low-inclination LEO never visible from Boston
+    # Grace-FO 2  Low polar orbit
+    tles = """\
+        INTEGRAL
+        1 27540U 02048A   20007.25125384  .00001047  00000-0  00000+0 0  9992
+        2 27540  51.8988 127.5680 8897013 285.8757   2.8911  0.37604578 17780
+        ANIK F-1R
+        1 28868U 05036A   20011.46493281 -.00000066  00000-0  00000+0 0  9999
+        2 28868   0.0175  50.4632 0002403 284.1276 195.8977  1.00270824 52609
+        PALAPA D
+        1 35812U 09046A   20008.38785173 -.00000341 +00000-0 +00000-0 0  9999
+        2 35812 000.0518 095.9882 0002721 218.8296 045.1595 01.00269700038098
+        Ariane 5B
+        1 44802U 19080C   20010.68544515  .00001373  00000-0  27860-3 0  9997
+        2 44802   5.1041 192.7327 7266711 217.6622  57.0965  2.30416801  1028
+        Swift
+        1 28485U 04047A   20010.76403232 +.00000826 +00000-0 +25992-4 0  9999
+        2 28485 020.5579 055.7027 0010957 208.9479 151.0347 15.04516653829549
+        GRACE-FO 2
+        1 43477U 18047B   20011.66650462 +.00000719  00000-0 +29559-4 0    08
+        2 43477  88.9974 159.0391 0019438 141.4770 316.8932 15.23958285 91199
+    """.splitlines()
+    expected = {'INTEGRAL': 36,
+                'ANIK F-1R': 14,
+                'PALAPA D': 0,
+                'Ariane 5B': 36,
+                'Swift': 0,
+                'GRACE-FO 2': 90}
+    for iline0 in range(0, len(tles)-3, 3):
+        sat = api.EarthSatellite(tles[1+iline0].strip(),
+                                 tles[2+iline0].strip(),
+                                 name=tles[iline0].strip())
+        topos = api.Topos('42.3581 N', '71.0636 W')  # Boston
+        timescale = api.load.timescale()
+        t0 = timescale.tai(2020, 1, 1)
+        t1 = timescale.tai(2020, 1, 15)
+        horizon = 20
+        nexpected = expected[sat.name]
+
+        times, yis = almanac.find_satellite_events(t0, t1, sat, topos, horizon=20)
+        assert(verify_sat_almanac(times, yis, sat, topos, horizon, nexpected))
+
+
+
+# Helper function to verify satellite events
+def verify_sat_almanac(times, yis, sat, topos, horizon, nexpected):
+    if nexpected is None:
+        print("Number of satellite events expected for", sat.name," not specified.  Got ", len(times))
+    else:
+        if len(times) != nexpected or len(yis) != nexpected:
+            raise RuntimeError("Unexpected number of satellite events")
+    if len(times) == 0:
+        return True     # Nothing to check
+    # Verify 1) rises/sets cross the horizon in the right direction
+    # 2) culminations are local maxima above horizon
+    # 3) No double rises or double sets
+    time_tolerance = 5/(24 * 60 * 60)   # Times must be accurate within 5 seconds
+    ts = times[0].ts     # Use the timescale passed by
+    altitudes_neartimes = [almanac.satellite_altitude(sat, topos, ts.tai(jd=times.tai + dt)).degrees
+                           for dt in (-time_tolerance, 0, time_tolerance)]
+    lastevent = None
+    for time, yi, (alt_before, alt_at, alt_after) in zip(
+            times, yis, zip(*altitudes_neartimes)):
+        eventname = almanac.SATELLITE_EVENTS[yi]
+        if eventname == 'rise':
+            assert(alt_before < alt_at < alt_after)  # It is going up
+            assert(alt_before < horizon < alt_after) # It is crossing horizon altitude
+            assert(lastevent != 'rise')     # Can't have two consecutive rises
+        elif eventname == 'culminate':
+            assert(alt_before < alt_at)
+            assert(alt_at > alt_after)
+            assert(alt_at > horizon)
+            # You can have two consecutive culminations (esp. for GEOs).
+        elif eventname == 'set':
+            assert(alt_before > alt_at > alt_after)  # It is going down
+            assert(alt_before > horizon > alt_after) # It is crossing horizon altitude
+            assert(lastevent != 'set')     # Can't have two consecutive sets
+        else:
+            raise RuntimeError("Unexpected satellite event type")
+        lastevent = eventname
+    return True


### PR DESCRIPTION
Draft pull request for Issue #115 .

Documentation and tests included.
(Tests cause a deprecation warning: np.float64->int .  How do I breakpoint to find where that happens?)

Usage:
```
t, y = almanac.find_satellite_events(t0, t1,
                satellite=satellite, topos=bluffton, horizon=10)
altitude, azimuth, distance = almanac.satellite_altitude(
                satellite=satellite, topos=bluffton, time=t, and_azdist=True)
```

Only covers rise/culminate/set.

Solar illumination may be added in a later issue.  