### PR TITLE
Fix for #54

### DIFF
--- a/skyfield/toposlib.py
+++ b/skyfield/toposlib.py
@@ -36,12 +36,14 @@ class Topos(VectorFunction):
               contain a longitude of the type '<float>[EW]'.
           2.  If latitude contains a string of the type '<float>[EW]' then reverse of the above is true.
           3.  Whatever type is contained in latitude, same type will be contained in longitude.
+          
+        As an addition, the elifs could test both latitude and longitude for type as opposed to just latitude, then
+        raise a generic error.
         """
 
         if latitude_degrees is not None:
-            latitude = Angle(degrees=latitude_degrees)
-            if longitude_degrees is not None:
-                longitude = Angle(degrees=longitude_degrees)
+            self.latitude = Angle(degrees=latitude_degrees)
+            self.longitude = Angle(degrees=longitude_degrees)
 
         elif isinstance(latitude, str):
             if lookup[latitude[-1]][1] == 'latitude':
@@ -52,8 +54,8 @@ class Topos(VectorFunction):
                 self.longitude = Angle(degrees=float(latitude[:-1].strip()) * lookup[latitude[-1]][0])
 
         elif isinstance(latitude, (float, tuple)):
-            self.latitude = latitude
-            self.longitude = longitude
+            self.latitude = _unsexagesimalize(latitude)
+            self.longitude = _unsexagesimalize(longitude)
 
         elif isinstance(latitude, Angle):
             self.latitude = latitude


### PR DESCRIPTION
This is my first contrib to any github project so please forgive any error in etiquette or process.

In looking at 54, I did choose to ignore the requirement to warn the user if they've reversed their N/S and E/W as there's enough information to just do the right thing.

I do get that you might want to warn them, and also you'll note my error checking really isn't totally robust.  I don't have a good feel for your style when it comes to the overhead of error checking so I just did what I would have done, with the knowledge that at least the technical solution is there if someone wants to add the error checking on top of it.

As a side note, I'm using skyfield in a standalone satellite tracking application and have enjoyed it enough that I wanted to contribute back, hence this PR.  Very pumped at the upcoming almanac stuff, I was in the process of implementing such a thing outside of skyfield when I saw the PRs.  

Finally, thanks for sharing skyfield, it's great!