### PR TITLE
Adding tests for KeplerLib

### DIFF
--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -7,6 +7,8 @@ from skyfield.api import load
 import os
 
 seterr(all='raise')
+#I encountered an underflow in keplerlib.stumpff where c3 is calculated using power series. I think it should be ignored.
+seterr(under='ignore') 
 
 # Test against HORIZONS.
 

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -54,6 +54,10 @@ def test_ele_to_vec():
 def _data_path(filename):
     return os.path.join(os.path.dirname(__file__), 'data', filename)
 
+times = linspace(-1e11, 1e11, 1001) # -3170 years to +3170 years, including 0 (in seconds)
+mu = 403503.2355022598
+dummy_time = load.timescale().utc(2018)
+
 def check_orbit(p, e, i, Om, w, v,
                 p_eps=None, e_eps=None, i_eps=None, Om_eps=None, w_eps=None, v_eps=None):
     pos0, vel0 = ele_to_vec(p, e, i, Om, w, v, mu)

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -12,7 +12,7 @@ seterr(under='ignore')
 
 # Test against HORIZONS.
 
-def test_against_horizons():
+def test_ele_to_vec():
     # See the following files in the Skyfield repository:
     #
     # horizons/ceres-orbital-elements

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -1,6 +1,6 @@
-from numpy import pi, seterr, linspace
+from numpy import pi, seterr, linspace, float_
 from skyfield.keplerlib import KeplerOrbit, propagate
-from skyfield.elementslib import OsculatingElements
+from skyfield.elementslib import OsculatingElements, mean_anomaly, eccentric_anomaly
 from skyfield.units import Angle, Distance, Velocity
 from skyfield.tests.test_elementslib import compare, ele_to_vec
 from skyfield.api import load
@@ -59,7 +59,7 @@ mu = 403503.2355022598
 dummy_time = load.timescale().utc(2018)
 
 def check_orbit(p, e, i, Om, w, v,
-                p_eps=None, e_eps=None, i_eps=None, Om_eps=None, w_eps=None, v_eps=None):
+                p_eps=None, e_eps=None, i_eps=None, Om_eps=None, w_eps=None, M_eps=None):
     pos0, vel0 = ele_to_vec(p, e, i, Om, w, v, mu)
 
     pos1, vel1 = propagate(pos0, vel0, 0, times, mu)
@@ -70,68 +70,71 @@ def check_orbit(p, e, i, Om, w, v,
     if i_eps: compare(i, ele.inclination.radians, i_eps, mod=True)
     if Om_eps: compare(Om, ele.longitude_of_ascending_node.radians, Om_eps, mod=True)
     if w_eps: compare(w, ele.argument_of_periapsis.radians, w_eps, mod=True)
-    if v_eps: compare(v, ele.true_anomaly.radians, v_eps, mod=True)
+    if M_eps: 
+        E0 = eccentric_anomaly(float_(v), float_(e), float_(p))
+        M0 = mean_anomaly(E0, float_(e))
 
+        mean_motion_per_s = ele.mean_motion_per_day.radians/24/3600
+        M1 = M0 + mean_motion_per_s * times
 
-times = linspace(-1e11, 1e11, 1001) # -3170 years to +3170 years, including 0
-mu = 403503.2355022598
-dummy_time = load.timescale().utc(2018)
+        compare(M1, ele.mean_anomaly.radians, M_eps, mod=True)
+
 
 def test_circular():
     check_orbit(p=300000, e=0, i=.5, Om=1, w=0, v=1,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, M_eps=1e-5)
 
 
 def test_circular_equatorial():
     check_orbit(p=300000, e=0, i=0, Om=0, w=0, v=1,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, M_eps=1e-5)
 
 
 def test_circular_polar():
     check_orbit(p=300000, e=0, i=pi/2, Om=1, w=0, v=1,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, M_eps=1e-5)
 
 
 def test_elliptical():
     check_orbit(p=300000, e=.3, i=1, Om=0, w=4, v=5,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7, M_eps=1e-5)
 
 
 def test_elliptical_equatorial():
     check_orbit(p=300000, e=.3, i=0, Om=0, w=1, v=5,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7, M_eps=1e-5)
 
 
 def test_elliptical_polar():
     check_orbit(p=300000, e=.2, i=pi/2, Om=1, w=2, v=3,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-8)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-8, M_eps=1e-5)
 
 
 def test_parabolic():
     check_orbit(p=300000, e=1, i=1, Om=0, w=4, v=3,
-                p_eps=1e-5, e_eps=1e-14, i_eps=1e-13, Om_eps=1e-13, w_eps=1e-13)
+                p_eps=1e-5, e_eps=1e-14, i_eps=1e-13, Om_eps=1e-13, w_eps=1e-13, M_eps=1e-5)
 
 
 def test_parabolic_equatorial():
     check_orbit(p=300000, e=1, i=0, Om=0, w=1, v=2,
-                p_eps=1e-5, e_eps=1e-14, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-13)
+                p_eps=1e-5, e_eps=1e-14, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-13, M_eps=1e-5)
 
 
 def test_parabolic_polar():
     check_orbit(p=300000, e=1, i=pi/2, Om=1, w=2, v=3,
-                p_eps=1e-5, e_eps=1e-14, i_eps=1e-14, Om_eps=1e-13, w_eps=1e-13)
+                p_eps=1e-5, e_eps=1e-14, i_eps=1e-14, Om_eps=1e-13, w_eps=1e-13, M_eps=1e-5)
 
 
 def test_hyperbolic():
     check_orbit(p=300000, e=1.3, i=1, Om=0, w=4, v=.5,
-                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6)
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6, M_eps=1e-5)
 
 
 def test_hyperbolic_equatorial():
     check_orbit(p=300000, e=1.3, i=0, Om=0, w=1, v=.5,
-                p_eps=1e0, e_eps=1e-6, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-6)
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-6, M_eps=1e-5)
 
 
 def test_hyperbolic_polar():
     check_orbit(p=300000, e=1.3, i=pi/2, Om=1, w=2, v=.5,
-                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6)
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6, M_eps=1e-5)

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -82,37 +82,37 @@ def check_orbit(p, e, i, Om, w, v,
 
 def test_circular():
     check_orbit(p=300000, e=0, i=.5, Om=1, w=0, v=1,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, M_eps=1e-5)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15)
 
 
 def test_circular_equatorial():
     check_orbit(p=300000, e=0, i=0, Om=0, w=0, v=1,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, M_eps=1e-5)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15)
 
 
 def test_circular_polar():
     check_orbit(p=300000, e=0, i=pi/2, Om=1, w=0, v=1,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, M_eps=1e-5)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15)
 
 
 def test_elliptical():
     check_orbit(p=300000, e=.3, i=1, Om=0, w=4, v=5,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7, M_eps=1e-5)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7, M_eps=1e-3)
 
 
 def test_elliptical_equatorial():
     check_orbit(p=300000, e=.3, i=0, Om=0, w=1, v=5,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7, M_eps=1e-5)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7, M_eps=1e-3)
 
 
 def test_elliptical_polar():
     check_orbit(p=300000, e=.2, i=pi/2, Om=1, w=2, v=3,
-                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-8, M_eps=1e-5)
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-8, M_eps=1e-3)
 
 
 def test_parabolic():
     check_orbit(p=300000, e=1, i=1, Om=0, w=4, v=3,
-                p_eps=1e-5, e_eps=1e-14, i_eps=1e-13, Om_eps=1e-13, w_eps=1e-13, M_eps=1e-5)
+                p_eps=1e-5, e_eps=1e-14, i_eps=1e-13, Om_eps=1e-13, w_eps=1e-13, M_eps=1e-4)
 
 
 def test_parabolic_equatorial():
@@ -127,14 +127,14 @@ def test_parabolic_polar():
 
 def test_hyperbolic():
     check_orbit(p=300000, e=1.3, i=1, Om=0, w=4, v=.5,
-                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6, M_eps=1e-5)
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6)
 
 
 def test_hyperbolic_equatorial():
     check_orbit(p=300000, e=1.3, i=0, Om=0, w=1, v=.5,
-                p_eps=1e0, e_eps=1e-6, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-6, M_eps=1e-5)
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-6)
 
 
 def test_hyperbolic_polar():
     check_orbit(p=300000, e=1.3, i=pi/2, Om=1, w=2, v=.5,
-                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6, M_eps=1e-5)
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6)


### PR DESCRIPTION
Sorry I wasn't able to respond earlier to your acceptance of #253, I'm very excited about it!

Since the last time I posted an update about `keplerlib.py` I've compared the results produced by the original FORTRAN function `prop2b` in the Spice library with `keplerlib.propagate` for a wide range of orbit types and times, and in the worst case scenario they differ in the 11th or 12th significant digit, so I feel pretty confident that `keplerlib.propagate()` is working properly.

One thing I want to mention is that I still don't think the `KeplerOrbit` object matches the data produced by Horizons, and I still don't think we should expect it to. To help explain why I'll give numbers to the steps the `KeplerOrbit` object uses to produce results so I can refer to them later:

1. Take a set of orbital elements and convert them into state vectors. This happens in `keplerlib.ele_to_vec()`, which is identical to the function `test_elementslib.ele_to_vec()` (it should probably live in one place and be imported to the other). It was originally written to help verify that `elementslib.py` was working properly.
2. Propagate the state vectors from step 1 to any other time. This happens in `keplerlib.propagate()`

The way `test_keplerlib.test_against_horizons` is currently written it's testing step one, but not step two. The set of orbital elements and state vectors from `horizons/ceres-orbital-elements` and `horizons/ceres-position` match each other exactly by definition because the elements are osculating elements. Because the time used to initialize the `KeplerOrbit` object is the same time given to the `KeplerOrbit._at()` method, the change in time is 0, so no propagation is happening; `keplerlib.propagate()` outputs the same vectors that it's given. In order to actually test step 2, the time given to the `KeplerOrbit._at()` method should be different from the one used to initialize the `KeplerOrbit` object. If you do this I think you'll find that the farther in time you propagate the orbit away from the time used for initialization, the greater it will differ from Horizons, due to Horizons not using 2 body propagation. I think the solution is to just rename the test to better describe what it does.

Currently the elements that are checked in the tests that make a round trip from elements to vectors and back are the ones that remain constant for Keplerian Orbits. These tests pass and they show that the propagated positions are on the correct orbit. What they don't show is that the positions are in the right place on the orbit. This PR adds a check of the mean anomaly which should verify that the propagated positions are in the right place in the orbits. The new check doesn't currently pass, but I think it ought to, and I'm working on figuring out why it doesn't.