### PR TITLE
Throw exception if calculation time is out of range

### DIFF
--- a/skyfield/errors.py
+++ b/skyfield/errors.py
@@ -12,7 +12,7 @@ class OutOfRangeTimeError(ValueError):
 
     - `first_valid_time`: the first supported time
     - `last_valid_time`: the last supported time
-    - `out_of_range_times`: a list of the out of range Time objects
+    - `out_of_range_times`: a list of booleans expressing which of the given times were out of range
     """
 
     def __init__(self, message, first_valid_time, last_valid_time, out_of_range_times):

--- a/skyfield/errors.py
+++ b/skyfield/errors.py
@@ -5,6 +5,22 @@ from functools import wraps
 class DeprecationError(Exception):
     """Explain that a Skyfield feature has been removed."""
 
+class OutOfRangeTimeError(ValueError):
+    """
+    This exception is thrown is the given time is out of tange of the supported times.
+    It has two extra attributes:
+
+    - `first_valid_time`: the first supported time
+    - `last_valid_time`: the last supported time
+    - `out_of_range_times`: a list of the out of range Time objects
+    """
+
+    def __init__(self, message, first_valid_time, last_valid_time, out_of_range_times):
+        self.args = message,
+        self.first_valid_time = first_valid_time
+        self.last_valid_time = last_valid_time
+        self.out_of_range_times = out_of_range_times
+
 def raise_error_for_deprecated_time_arguments(method):
     @wraps(method)
     def wrapper(self, jd=None, utc=None, tai=None, tt=None, tdb=None):

--- a/skyfield/jpllib.py
+++ b/skyfield/jpllib.py
@@ -208,19 +208,15 @@ class ChebyshevPosition(SPICESegment):
     def _at(self, t):
         try:
             position, velocity = self.spk_segment.compute_and_differentiate(t.tdb)
-            return position / AU_KM, velocity / AU_KM, None, None
         except OutOfRangeError as e:
-            start_time = t.ts.tdb(jd=self.spk_segment.start_jd)
-            end_time = t.ts.tdb(jd=self.spk_segment.end_jd)
-            out_of_range_times = []
+            first_valid = t.ts.tdb(jd=self.spk_segment.start_jd)
+            last_valid = t.ts.tdb(jd=self.spk_segment.end_jd)
 
-            for i, time in enumerate(t):
-                if e.out_of_range_times[i]:
-                    out_of_range_times.append(time)
+            raise OutOfRangeTimeError('out of range times: must be between %s and %s' % (first_valid.utc_iso(),
+                                                                                         last_valid.utc_iso()),
+                                      first_valid, last_valid, e.out_of_range_times)
 
-            raise OutOfRangeTimeError('out of range times: must be between %s and %s' % (start_time.utc_iso(),
-                                                                                         end_time.utc_iso()),
-                                      start_time, end_time, out_of_range_times)
+        return position / AU_KM, velocity / AU_KM, None, None
 
 
 class ChebyshevPositionVelocity(SPICESegment):


### PR DESCRIPTION
Add support for the `OutOfRangeError` exception thrown by JplEphem in brandon-rhodes/python-jplephem#36.

Basically, we catch the raised exception on JplEphem's side and re-throw a Skyfield-specific one with the times converted in `Time` objects.

Fix #319 