### PR TITLE
Update urlopen call to not use deprecated cafile keyword

### DIFF
--- a/skyfield/iokit.py
+++ b/skyfield/iokit.py
@@ -42,6 +42,7 @@ try:
 except:
     from urlparse import urlparse
     from urllib2 import urlopen
+from ssl import create_default_context
 
 # If we are running under the built-in IDLE development environment, we
 # cannot use '\r' to keep repainting the current line as a progress bar:
@@ -574,7 +575,8 @@ def download(url, path, verbose=None, blocksize=128*1024):
     """
     tempname = path + '.download'
     try:
-        connection = urlopen(url, cafile=certifi.where())
+        ssl_context = create_default_context(cafile=certifi.where())
+        connection = urlopen(url, context=ssl_context)
     except Exception as e:
         e2 = IOError('cannot get {0} because {1}'.format(url, e))
         e2.__cause__ = None


### PR DESCRIPTION
Skyfield's `iokit.py` is currently using the `cafile` keyword in `urlopen`, which is deprecated from Python 3.6 on (see the deprecation note at the very end of the `urlopen` section here: https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen). This PR updates the call to `urlopen` to use what I think to be the intended replacement.

While in principle a minor issue, it turns out to lead very indirectly to some failing tests downstream - see astropy/astropy#10200 for more detail on what lead me down this path... But regardless of the downstream effect, this would seem to be more what the current python standard library intends!