### PR TITLE
Fix typo in the EphemerisRangeError constructor

### DIFF
--- a/skyfield/errors.py
+++ b/skyfield/errors.py
@@ -18,7 +18,7 @@ class EphemerisRangeError(ValueError):
     def __init__(self, message, start_time, end_time, time_mask, segment):
         self.args = message,
         self.start_time = start_time
-        self.end_time = start_time
+        self.end_time = end_time
         self.time_mask = time_mask
         self.segment = segment
 

--- a/skyfield/tests/test_api.py
+++ b/skyfield/tests/test_api.py
@@ -46,7 +46,7 @@ def test_exception_raised_for_dates_outside_ephemeris(ts):
     e = a.exception
     assert e.args == (message,)
     assert e.start_time.tdb == 2414864.5
-    assert e.end_time.tdb == 2414864.5
+    assert e.end_time.tdb == 2471184.5
     assert e.time_mask == [True]
     assert e.segment is eph['earth'].positives[0].spk_segment
 


### PR DESCRIPTION
Fixing a small mistake introduced in commit c2181134d70a2a8ba104ba0db5b39b6cb633263a, in the constructor of the new `EphemerisRangeError`.