### PR TITLE
added xp/yp passthrough in sgp4lib.ITRF_position_velocity_error

### DIFF
--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -138,7 +138,7 @@ class EarthSatellite(VectorFunction):
             message = SGP4_ERRORS[error] if error else None
             return array(position), array(velocity), message
 
-    def ITRF_position_velocity_error(self, t):
+    def ITRF_position_velocity_error(self, t, xp=0.0, yp=0.0):
         """Return the ITRF position, velocity, and error at time `t`.
 
         The position is an x,y,z vector measured in au, the velocity is
@@ -150,7 +150,7 @@ class EarthSatellite(VectorFunction):
         rTEME /= AU_KM
         vTEME /= AU_KM
         vTEME *= DAY_S
-        rITRF, vITRF = TEME_to_ITRF(t.ut1, rTEME, vTEME)
+        rITRF, vITRF = TEME_to_ITRF(t.ut1, rTEME, vTEME, xp, yp)
         return rITRF, vITRF, error
 
     def _at(self, t):


### PR DESCRIPTION
I added `0.0`-defaulted polar motion pass-through `kwargs` to `sgp4lib.ITRF_position_velocity_error()`. Currently in my project I wish to convert SGP4 propagated TEME coords to ITRF coords and wish to specify polar motion coefficients. Currently, `ITRF_position_velocity_error()` calls `TEME_to_ITRF()` without specifying the coefficients, so they are always kept as `0.0`. To get around this, I have had to manually call the private `_position_and_velocity_TEME_km()` and then `TEME_to_ITRF()`. This is not a clean solution, especially as `TEME_to_ITRF()` already accepts polar motion coefficients as arguments.