### PR TITLE
Added is_sunlit method and docs for usage - Issue #362

### DIFF
--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -410,7 +410,7 @@ and will require providing ephemeris data.
 
 .. testsetup::
 
-  from datetime import datetime, timezone
+  from datetime import datetime, timezone, timedelta
   from skyfield.api import load, EarthSatellite
 
   # Set up the ISS as an example and load ephemeris.

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -413,14 +413,14 @@ times you desire (when the TLE is still accurate):
 
   from skyfield.api import load
   satellite = by_name['ISS (ZARYA)']
-  de421.bsp = load('de421.bsp')
+  de421 = load('de421.bsp')
 
   # Define the times you are interested in
   minutes = range(0, 90, 10)
   times = ts.utc(2020, 4, 29, 0, minutes)
 
   # Calculate the sunlit vector
-  sunlit = satellite.is_sunlit(ephemeris=de421.bsp, times=times)
+  sunlit = satellite.is_sunlit(ephemeris=de421, times=times)
   for idx, time in enumerate(times):
       print(time.utc_jpl(), "{} is sunlit: {}".format(satellite.name,sunlit[idx]))
 
@@ -536,7 +536,7 @@ so it supports all of the standard Skyfield date methods:
     from skyfield.api import EarthSatellite
 
     text = """
-    GOCE                    
+    GOCE
     1 34602U 09013A   13314.96046236  .14220718  20669-5  50412-4 0   930
     2 34602 096.5717 344.5256 0009826 296.2811 064.0942 16.58673376272979
     """

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -406,35 +406,21 @@ with the :meth:`~skyfield.sgp4lib.EarthSatellite.is_sunlit()` method,
 which provides a boolean response for each corresponding time provided.
 This requires knowledge of the earth and sun,
 and will require providing ephemeris data.
-
-
-.. testsetup::
-
-  from datetime import datetime, timezone, timedelta
-  from skyfield.api import load, EarthSatellite
-
-  # Set up the ISS as an example and load ephemeris.
-  TLE = """ISS (ZARYA)
-  1 25544U 98067A   20120.54828704  .00001508  00000-0  35122-4 0  9994
-  2 25544  51.6452 229.1987 0001494 205.5139 329.7843 15.49330212224471"""
-
-  name, tle_1, tle_2 = TLE.splitlines()
-  ts = load.timescale()
-  satellite = EarthSatellite(tle_1, tle_2, name=name, ts=ts)
-  ephemeris = load('de421.bsp')
-
-Once you have the above defined, you can check
-if the satellite will be illuminated at whatever
+You can check if the satellite will be illuminated at whatever
 times you desire (when the TLE is still accurate):
 
 .. testcode::
 
+  from skyfield.api import load
+  satellite = by_name['ISS (ZARYA)']
+  de421.bsp = load('de421.bsp')
+
   # Define the times you are interested in
-  start_time = datetime(2020, 4, 29, tzinfo=timezone.utc)
-  times = ts.utc([start_time + timedelta(minutes=step) for step in range(0, 90, 10)])
+  minutes = range(0, 90, 10)
+  times = ts.utc(2020, 4, 29, 0, minutes)
 
   # Calculate the sunlit vector
-  sunlit = satellite.is_sunlit(ephemeris=ephemeris, times=times)
+  sunlit = satellite.is_sunlit(ephemeris=de421.bsp, times=times)
   for idx, time in enumerate(times):
       print(time.utc_jpl(), "{} is sunlit: {}".format(satellite.name,sunlit[idx]))
 
@@ -442,15 +428,15 @@ This produces a `sunlit` vector of booleans you can reference alongside your tim
 
 .. testoutput::
 
-  A.D. 2020-Apr-29 00:00:00.0000 UT ISS (ZARYA) is sunlit: False
-  A.D. 2020-Apr-29 00:10:00.0000 UT ISS (ZARYA) is sunlit: False
-  A.D. 2020-Apr-29 00:20:00.0000 UT ISS (ZARYA) is sunlit: True
-  A.D. 2020-Apr-29 00:30:00.0000 UT ISS (ZARYA) is sunlit: True
-  A.D. 2020-Apr-29 00:40:00.0000 UT ISS (ZARYA) is sunlit: True
-  A.D. 2020-Apr-29 00:50:00.0000 UT ISS (ZARYA) is sunlit: True
+  A.D. 2020-Apr-29 00:00:00.0000 UT ISS (ZARYA) is sunlit: True
+  A.D. 2020-Apr-29 00:10:00.0000 UT ISS (ZARYA) is sunlit: True
+  A.D. 2020-Apr-29 00:20:00.0000 UT ISS (ZARYA) is sunlit: False
+  A.D. 2020-Apr-29 00:30:00.0000 UT ISS (ZARYA) is sunlit: False
+  A.D. 2020-Apr-29 00:40:00.0000 UT ISS (ZARYA) is sunlit: False
+  A.D. 2020-Apr-29 00:50:00.0000 UT ISS (ZARYA) is sunlit: False
   A.D. 2020-Apr-29 01:00:00.0000 UT ISS (ZARYA) is sunlit: True
   A.D. 2020-Apr-29 01:10:00.0000 UT ISS (ZARYA) is sunlit: True
-  A.D. 2020-Apr-29 01:20:00.0000 UT ISS (ZARYA) is sunlit: False
+  A.D. 2020-Apr-29 01:20:00.0000 UT ISS (ZARYA) is sunlit: True
 
 You can see when it is sunlit at the given times!
 

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -536,7 +536,7 @@ so it supports all of the standard Skyfield date methods:
     from skyfield.api import EarthSatellite
 
     text = """
-    GOCE
+    GOCE                    
     1 34602U 09013A   13314.96046236  .14220718  20669-5  50412-4 0   930
     2 34602 096.5717 344.5256 0009826 296.2811 064.0942 16.58673376272979
     """

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -410,10 +410,10 @@ and will require providing ephemeris data.
 
 .. testsetup::
 
-      from datetime import datetime, timezone
-      from skyfield.api import load, EarthSatellite
-  
-      # Set up the ISS as an example and load ephemeris.
+  from datetime import datetime, timezone
+  from skyfield.api import load, EarthSatellite
+
+  # Set up the ISS as an example and load ephemeris.
   TLE = """ISS (ZARYA)
   1 25544U 98067A   20120.54828704  .00001508  00000-0  35122-4 0  9994
   2 25544  51.6452 229.1987 0001494 205.5139 329.7843 15.49330212224471"""

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -427,8 +427,8 @@ times you desire (when the TLE is still accurate):
 .. testcode::
 
   # Define the times you are interested in
-  time = datetime(2020, 4, 29, tzinfo=timezone.utc)
-  times = ts.utc([time + timedelta(minutes=step) for step in range(0, 90, 10)])
+  start_time = datetime(2020, 4, 29, tzinfo=timezone.utc)
+  times = ts.utc([start_time + timedelta(minutes=step) for step in range(0, 90, 10)])
 
   # Calculate the sunlit vector
   sunlit = satellite.is_sunlit(ephemeris=ephemeris, times=times)

--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -410,7 +410,10 @@ and will require providing ephemeris data.
 
 .. testsetup::
 
-  # Set up the ISS as an example and load ephemeris.
+      from datetime import datetime, timezone
+      from skyfield.api import load, EarthSatellite
+  
+      # Set up the ISS as an example and load ephemeris.
   TLE = """ISS (ZARYA)
   1 25544U 98067A   20120.54828704  .00001508  00000-0  35122-4 0  9994
   2 25544  51.6452 229.1987 0001494 205.5139 329.7843 15.49330212224471"""

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -27,7 +27,6 @@ _identity = identity(3)
 _infs = array(('-inf', 'inf'), float)
 _ts = Timescale(array((_infs, (0.0, 0.0))), _infs, array((37.0, 37.0)))
 
-
 class EarthSatellite(VectorFunction):
     """An Earth satellite loaded from a TLE file and propagated with SGP4.
 
@@ -268,9 +267,7 @@ class EarthSatellite(VectorFunction):
         i = jd.argsort()
         return ts.tt_jd(jd[i]), v[i]
 
-
 _second = 1.0 / (24.0 * 60.0 * 60.0)
-
 
 def theta_GMST1982(jd_ut1):
     """Return the angle of Greenwich Mean Standard Time 1982 given the JD.
@@ -288,7 +285,6 @@ def theta_GMST1982(jd_ut1):
     theta = (jd_ut1 % 1.0 + g * _second % 1.0) * tau
     theta_dot = (1.0 + dg * _second / 36525.0) * tau
     return theta, theta_dot
-
 
 def TEME_to_ITRF(jd_ut1, rTEME, vTEME, xp=0.0, yp=0.0):
     """Convert TEME position and velocity into standard ITRS coordinates.

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -97,9 +97,9 @@ class EarthSatellite(VectorFunction):
         # TODO: just use the Julian dates instead
         two_digit_year = sat.epochyr
         if two_digit_year < 57:
-            year = two_digit_year + 2000
+            year = two_digit_year + 2000;
         else:
-            year = two_digit_year + 1900
+            year = two_digit_year + 1900;
 
         self.epoch = ts.utc(year, 1, sat.epochdays)
 


### PR DESCRIPTION
This is a first pass. I tried to match as much as possible, but I'd be happy to restructure/reconfigure if you'd like. This is to add the feature I requested in https://github.com/skyfielders/python-skyfield/issues/362

I obviously pulled heavily from https://space.stackexchange.com/questions/37713/how-can-i-calculate-if-a-satellite-is-currently-in-sunlight-or-eclipse-using-pye/40217#40217 (as in copied and cleaned it up). 

I added documentation for usage, let me know if there is anything else I should add beyond that. (Wasn't sure about testing, since it's really just geometry and vector math)