### PR TITLE
use numpy to compare floats

### DIFF
--- a/skyfield/tests/test_planetarylib.py
+++ b/skyfield/tests/test_planetarylib.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 from skyfield.api import PlanetaryConstants, T0, load
 from skyfield.constants import AU_KM, AU_M
 from skyfield.positionlib import ICRF
@@ -43,11 +44,11 @@ def test_frame_rotation_matrices():
     ]
 
     R = frame.rotation_at(ts.tdb_jd(tdb))
-    assert (R == desired_rotation).all()  # Boom.
+    assert_allclose(R, desired_rotation)
 
     R2, Rv = frame.rotation_and_rate_at(ts.tdb_jd(tdb))
-    assert (R == R2).all()
-    assert (Rv == desired_rate).all()  # Boom.
+    assert_allclose(R, R2)
+    assert_allclose(Rv, desired_rate)
 
     # Second, a moment when the angle W is more than 2500 radians.
 
@@ -93,11 +94,11 @@ def test_frame_rotation_matrices():
     frame = pc.build_frame_named('MOON_ME_DE421')
     R = frame.rotation_at(ts.tdb_jd(tdb))
     delta = abs(R - desired_rotation)
-    assert (R == desired_rotation).all()
+    assert_allclose(R, desired_rotation)
 
     R2, Rv = frame.rotation_and_rate_at(ts.tdb_jd(tdb))
-    assert (R == R2).all()
-    assert (Rv == desired_rate).all()
+    assert_allclose(R, R2)
+    assert_allclose(Rv, desired_rate)
 
 def test_rotating_vector_into_frame():
     et_seconds = 259056665.1855896


### PR DESCRIPTION
Trying to [package python-skyfield for openSUSE](https://build.opensuse.org/package/show/devel:languages:python:numeric/python-skyfield), I kept getting assertion errors during unit testing. Using `numpy.testing.assert_allclose()` instead of the `==` operator for float arrays helps.