### PR TITLE
Remove checks that are too strict in ele_to_vec

### DIFF
--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -267,22 +267,6 @@ def ele_to_vec(p, e, i, Om, w, v, mu):
 
     https://web.archive.org/web/*/http://ccar.colorado.edu/asen5070/handouts/kep2cart_2002.doc
     """
-    # Checks that longitude of ascending node is 0 if inclination is 0
-    if isinstance(i, ndarray) or isinstance(Om, ndarray):
-        if ((i==0)*(Om!=0)).any():
-            raise ValueError('If inclination is 0, longitude of ascending node must be 0')
-    else:
-        if i==0 and Om!=0:
-            raise ValueError('If inclination is 0, longitude of ascending node must be 0')
-
-    # Checks that argument of periapsis is 0  if eccentricity is 0
-    if isinstance(e, ndarray) or isinstance(w, ndarray):
-        if ((e==0)*(w!=0)).any():
-            raise ValueError('If eccentricity is 0, argument of periapsis must be 0')
-    else:
-        if e==0 and w!=0:
-            raise ValueError('If eccentricity is 0, argument of periapsis must be 0')
-
     # Checks that true anomaly is less than arccos(-1/e) for hyperbolic orbits
     if isinstance(e, ndarray) and isinstance(v, ndarray):
         inds = (e>1)
@@ -299,11 +283,13 @@ def ele_to_vec(p, e, i, Om, w, v, mu):
         if e>1 and v>arccos(-1/e):
             raise ValueError('If eccentricity is >1, abs(true anomaly) cannot be more than arccos(-1/e)')
 
-    # Checks that inclination is between 0 and pi
+    # Checks that inclination is in the range [0, pi]
     if isinstance(i, ndarray):
-        assert ((i>=0) * (i < pi)).all()
+        if not ((i>=0) * (i <= pi)).all():
+            raise ValueError('Inclination outside the range [0, pi] radians')
     else:
-        assert i>=0 and i<pi
+        if not 0 <= i <= pi:
+            raise ValueError('Inclination outside the range [0, pi] radians')
 
     r = p/(1 + e*cos(v))
     h = sqrt(p*mu)

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -138,8 +138,18 @@ def test_circular_equatorial():
                 p_eps=1e-2, e_eps=1e-8, i_eps=1e-15)
 
 
+def test_circular_retrograde_equatorial():
+    check_orbit(p=300000, e=0, i=pi, Om=0, w=0, v=1,
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15)
+
+
 def test_circular_polar():
     check_orbit(p=300000, e=0, i=pi/2, Om=1, w=0, v=1,
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15)
+
+
+def test_circular_non_zero_arg_of_periapsis():
+    check_orbit(p=300000, e=0, i=.5, Om=1, w=.5, v=1,
                 p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15)
 
 
@@ -150,6 +160,11 @@ def test_elliptical():
 
 def test_elliptical_equatorial():
     check_orbit(p=300000, e=.3, i=0, Om=0, w=1, v=5,
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7)
+
+
+def test_elliptical_retrograde_equatorial():
+    check_orbit(p=300000, e=.3, i=pi, Om=0, w=4, v=5,
                 p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-7)
 
 
@@ -168,6 +183,11 @@ def test_parabolic_equatorial():
                 p_eps=1e-5, e_eps=1e-14, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-13)
 
 
+def test_parabolic_retrograde_equatorial():
+    check_orbit(p=300000, e=1, i=pi, Om=0, w=1, v=2,
+                p_eps=1e-5, e_eps=1e-14, i_eps=1e-15, Om_eps=1e-13, w_eps=1e-13)
+
+
 def test_parabolic_polar():
     check_orbit(p=300000, e=1, i=pi/2, Om=1, w=2, v=3,
                 p_eps=1e-5, e_eps=1e-14, i_eps=1e-14, Om_eps=1e-13, w_eps=1e-13)
@@ -183,6 +203,16 @@ def test_hyperbolic_equatorial():
                 p_eps=1e0, e_eps=1e-6, i_eps=1e-15, Om_eps=1e-15, w_eps=1e-6)
 
 
+def test_hyperbolic_retrograde_equatorial():
+    check_orbit(p=300000, e=1.3, i=pi, Om=0, w=1, v=.5,
+                p_eps=1e0, e_eps=1e-6, i_eps=1e-15, Om_eps=1e-9, w_eps=1e-6)
+
+
 def test_hyperbolic_polar():
     check_orbit(p=300000, e=1.3, i=pi/2, Om=1, w=2, v=.5,
                 p_eps=1e0, e_eps=1e-6, i_eps=1e-10, Om_eps=1e-10, w_eps=1e-6)
+
+
+def test_equatorial_non_zero_longitude_of_ascending_node():
+    check_orbit(p=300000, e=.3, i=1, Om=0, w=4, v=5,
+                p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, w_eps=1e-7)

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -214,5 +214,5 @@ def test_hyperbolic_polar():
 
 
 def test_equatorial_non_zero_longitude_of_ascending_node():
-    check_orbit(p=300000, e=.3, i=1, Om=0, w=4, v=5,
+    check_orbit(p=300000, e=.3, i=0, Om=0, w=4, v=5,
                 p_eps=1e-2, e_eps=1e-8, i_eps=1e-15, w_eps=1e-7)


### PR DESCRIPTION
This fixes #432 by removing checks that were to strict in the function `keplerlib.ele_to_vec`. They were too strict because they disallowed any orbit whose elements couldn't be exactly reversed by the OsculatingElements object even if they were valid, i.e. element sets that have a non-zero value for an indeterminate element. I added tests to make sure no errors occur in these cases.

I also found that the check for inclinations was too strict and disallowed inclinations of exactly pi (retrograde equatorial orbits). I added tests for different types of retrograde equatorial orbits.