### PR TITLE
Fix find_maxima call in find_minima function

### DIFF
--- a/skyfield/searchlib.py
+++ b/skyfield/searchlib.py
@@ -85,7 +85,7 @@ def find_minima(start_time, end_time, f, epsilon=1.0 / DAY_S, num=12):
     def g(t): return -f(t)
     g.rough_period = getattr(f, 'rough_period', None)
     g.step_days = getattr(f, 'step_days', None)
-    t, y = find_maxima(start_time, end_time, g, epsilon=1.0 / DAY_S, num=12)
+    t, y = find_maxima(start_time, end_time, g, epsilon, num)
     return t, -y
 
 def find_maxima(start_time, end_time, f, epsilon=1.0 / DAY_S, num=12):


### PR DESCRIPTION
Pass `epsilon`and `num` parameters from `find_minima` to `find_maxima`.

I'd like to take advantage of this PR to add documentation about these parameters and the `rough_period` attribute set to the function, since they seem very important in the calculation. Personally, I've always failed to really understand what their purpose is. Can you explain these, so I can update the docs?