### PR TITLE
SpiceKernel allows slicing and tuple indexing

### DIFF
--- a/skyfield/jpllib.py
+++ b/skyfield/jpllib.py
@@ -164,6 +164,11 @@ class SpiceKernel(object):
 
     def __getitem__(self, target):
         """Return a vector function for computing the location of `target`."""
+        if isinstance(target, slice):
+            i = range( *target.indices(10) )
+            return ( self[x] for x in i )
+        if isinstance(target, tuple):
+            return ( self[x] for x in target )
         target = self.decode(target)
         segments = self.segments
         segment_dict = dict((segment.target, segment) for segment in segments)


### PR DESCRIPTION
SpiceKernel is implemented with a dictionary instead
of integer indexing, but in user-land, it's natural
to try slices sometimes.  This allows the following
code to run ...

    from skyfield.api import load
    bodies = load('de421.bsp')
    earth, mars = bodies[3:5]
    earth, mars = bodies[('mars','earth')]