### PR TITLE
Vectorized `keplerlib.propagate`

### DIFF
--- a/skyfield/data/mpc.py
+++ b/skyfield/data/mpc.py
@@ -228,7 +228,7 @@ def comet_orbit(row, ts, gm_km3_s2):
 
 def _comet_orbits(rows, ts, gm_km3_s2):
     e = rows.eccentricity.values
-    p = 1 - e**2
+    p = 1 - e*e
     parabolic = (e == 1.0)
     p[parabolic] = rows.perihelion_distance_au.values[parabolic] * 2.0
     p[~parabolic] *= rows.perihelion_distance_au.values[~parabolic]/ (1.0 - e[~parabolic])

--- a/skyfield/data/mpc.py
+++ b/skyfield/data/mpc.py
@@ -226,7 +226,7 @@ def comet_orbit(row, ts, gm_km3_s2):
     )
     comet._rotation = inertial_frames['ECLIPJ2000'].T
     return comet
-    
+
 def comet_orbits(rows, ts, gm_km3_s2):
     p = np.empty(len(rows))
     e = rows.eccentricity.values

--- a/skyfield/data/mpc.py
+++ b/skyfield/data/mpc.py
@@ -227,7 +227,7 @@ def comet_orbit(row, ts, gm_km3_s2):
     comet._rotation = inertial_frames['ECLIPJ2000'].T
     return comet
 
-def comet_orbits(rows, ts, gm_km3_s2):
+def _comet_orbits(rows, ts, gm_km3_s2):
     p = np.empty(len(rows))
     e = rows.eccentricity.values
     parabolic = (e == 1.0)

--- a/skyfield/data/mpc.py
+++ b/skyfield/data/mpc.py
@@ -5,7 +5,6 @@ import io
 import re
 
 import pandas as pd
-import numpy as np
 
 from ..data.spice import inertial_frames
 from ..keplerlib import _KeplerOrbit

--- a/skyfield/data/mpc.py
+++ b/skyfield/data/mpc.py
@@ -228,10 +228,10 @@ def comet_orbit(row, ts, gm_km3_s2):
 
 def _comet_orbits(rows, ts, gm_km3_s2):
     e = rows.eccentricity.values
-    p = 1 - e*e
     parabolic = (e == 1.0)
-    p[parabolic] = rows.perihelion_distance_au.values[parabolic] * 2.0
-    p[~parabolic] *= rows.perihelion_distance_au.values[~parabolic]/ (1.0 - e[~parabolic])
+    p = (1 - e*e) / (1.0 - e + parabolic)
+    p[parabolic] += 2.0
+    p *= rows.perihelion_distance_au.values
 
     t_perihelion = ts.tt(rows.perihelion_year.values, rows.perihelion_month.values,
                          rows.perihelion_day.values)

--- a/skyfield/data/mpc.py
+++ b/skyfield/data/mpc.py
@@ -228,12 +228,11 @@ def comet_orbit(row, ts, gm_km3_s2):
     return comet
 
 def _comet_orbits(rows, ts, gm_km3_s2):
-    p = np.empty(len(rows))
     e = rows.eccentricity.values
+    p = 1 - e**2
     parabolic = (e == 1.0)
     p[parabolic] = rows.perihelion_distance_au.values[parabolic] * 2.0
-    a = rows.perihelion_distance_au.values[~parabolic]/ (1.0 - e[~parabolic])
-    p[~parabolic] = a * (1.0 - (e[~parabolic])**2)
+    p[~parabolic] *= rows.perihelion_distance_au.values[~parabolic]/ (1.0 - e[~parabolic])
 
     t_perihelion = ts.tt(rows.perihelion_year.values, rows.perihelion_month.values,
                          rows.perihelion_day.values)

--- a/skyfield/functions.py
+++ b/skyfield/functions.py
@@ -19,16 +19,6 @@ def dots(v, u):
     """
     return (v * u).sum(axis=0)
 
-def crosses(v, u):
-    """Given one or more vectors in `v` and `u`, return their cross products.
-
-    This works whether `v` and `u` each have the shape ``(3,)``, or
-    whether they are each whole arrays of corresponding x, y, and z
-    coordinates and have shape ``(3, N)``.
-
-    """
-    return array([v[1]*u[2] - v[2]*u[1], v[2]*u[0] - v[0]*u[2], v[0]*u[1] - v[1]*u[0]])
-
 def _T(M):
     """Swap the first two dimensions of an array."""
     return rollaxis(M, 1)

--- a/skyfield/functions.py
+++ b/skyfield/functions.py
@@ -19,6 +19,16 @@ def dots(v, u):
     """
     return (v * u).sum(axis=0)
 
+def crosses(v, u):
+    """Given one or more vectors in `v` and `u`, return their cross products.
+
+    This works whether `v` and `u` each have the shape ``(3,)``, or
+    whether they are each whole arrays of corresponding x, y, and z
+    coordinates and have shape ``(3, N)``.
+
+    """
+    return array([v[1]*u[2] - v[2]*u[1], v[2]*u[0] - v[0]*u[2], v[0]*u[1] - v[1]*u[0]])
+
 def _T(M):
     """Swap the first two dimensions of an array."""
     return rollaxis(M, 1)

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -376,8 +376,8 @@ dpmax = sys.float_info.max
 
 
 def bracket(num, end1, end2):
-    low = num<end1[:, newaxis]
-    high = num>end2[:, newaxis]
+    low = num<end1
+    high = num>end2
 
     num[low] = repeat(end1, sum(low, axis=1))
     num[high] = repeat(end2, sum(high, axis=1))
@@ -531,7 +531,7 @@ def propagate(position, velocity, t0, t1, gm):
     t0 = atleast_1d(t0)
     dt = t1 - t0[:, newaxis]
 
-    x = bracket(dt/bq[:, newaxis], -bound, bound)
+    x = bracket(dt/bq[:, newaxis], -bound[:, newaxis], bound[:, newaxis])
     kfun = kepler(x)
 
     past = dt < 0

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -522,6 +522,7 @@ def propagate(position, velocity, t0, t1, gm):
     logbound = (log(1.5) + log(dpmax) - log(maxc[~hyperbolic])) / 3
     bound[~hyperbolic] = exp(logbound)
 
+    # each of these arrays has 1 entry per orbit, so its shape is (#orbits, 1)
     f = f[:, newaxis]
     bq = bq[:, newaxis]
     b2rv = b2rv[:, newaxis]
@@ -540,6 +541,10 @@ def propagate(position, velocity, t0, t1, gm):
 
     t1 = atleast_1d(t1)
     t0 = atleast_1d(t0)
+    if len(t0) == 1:
+        t0 = repeat(t0, position.shape[1])
+
+    # shape of 2 dimensional arrays from here on out should be (#orbits, len(t1))
     dt = t1 - t0[:, newaxis]
 
     x = bracket(dt/bq, -bound, bound)

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -4,8 +4,8 @@ import sys
 import math
 from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
                   clip, copy, copyto, cos, cosh, exp, full_like, log, ndarray,
-                  newaxis, ones_like, pi, power, repeat, sin, sinh, squeeze,
-                  sqrt, sum, tan, tanh, zeros_like)
+                  newaxis, pi, power, repeat, sin, sinh, squeeze, sqrt, sum,
+                  tan, tanh, zeros_like)
 
 from skyfield.constants import AU_KM, DAY_S, DEG2RAD
 from skyfield.functions import dots, length_of, mxv
@@ -599,7 +599,7 @@ def propagate(position, velocity, t0, t1, gm):
 
         copyto(x, upper, where=(not_done & (lower>upper)))
         copyto(x, (upper+lower)/2, where=(not_done & (lower<=upper)))
-        
+
         lcount += 1
         not_done = (lower < x) & (x < upper) & (lcount < mostc)
 

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -2,9 +2,10 @@ from __future__ import division
 
 import sys
 import math
-from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d, atleast_2d, cos, cosh,
-                  exp, log, ndarray, newaxis, ones_like, pi, power,
-                  repeat, sin, sinh, squeeze, sqrt, sum, tan, tanh, zeros_like)
+from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
+                  atleast_2d, cos, cosh, exp, log, ndarray, newaxis,
+                  ones_like, pi, power, repeat, sin, sinh, squeeze, sqrt, sum,
+                  tan, tanh, zeros_like)
 
 from skyfield.constants import AU_KM, DAY_S, DEG2RAD
 from skyfield.functions import dots, length_of, mxv, crosses

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -3,7 +3,7 @@ from __future__ import division
 import sys
 import math
 from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
-                  clip, copyto, cos, cosh, exp, full_like, log, ndarray,
+                  clip, copy, copyto, cos, cosh, exp, full_like, log, ndarray,
                   newaxis, ones_like, pi, power, repeat, sin, sinh, squeeze,
                   sqrt, sum, tan, tanh, zeros_like)
 
@@ -575,7 +575,8 @@ def propagate(position, velocity, t0, t1, gm):
                              'to {2}.'.format(dt, kepler(-bound), kepler(bound)))
         kfun[future] = kepler_1d(x[future], orb_ind)
 
-    x = amin(array([upper, amax(array([lower, (lower+upper)/2]), axis=0)]), axis=0)
+    x = copy(upper)
+    copyto(x, (upper+lower)/2, where=(lower<=upper))
 
     lcount = zeros_like(dt)
     mostc = full_like(dt, 1000)
@@ -596,8 +597,9 @@ def propagate(position, velocity, t0, t1, gm):
         mostc[condition] = 64
         lcount[condition] = 0
 
-        # vectorized version of min(upper, max(lower, (upper + lower)/2))
-        x[not_done] = amin(array([upper[not_done], amax(array([lower[not_done], (lower[not_done]+upper[not_done])/2]), axis=0)]), axis=0)
+        copyto(x, upper, where=(not_done & (lower>upper)))
+        copyto(x, (upper+lower)/2, where=(not_done & (lower<=upper)))
+        
         lcount += 1
         not_done = (lower < x) & (x < upper) & (lcount < mostc)
 

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -610,8 +610,8 @@ def propagate(position, velocity, t0, t1, gm):
     c0, c1, c2, c3 = stumpff(x*x*f)
     br = c0*br0 + x*(c1*b2rv + x*(c2*bq))
 
-    pc = 1 - x**2 * c2 * qovr0
-    vc = dt - x**3 * c3 * bq
+    pc = 1 - qovr0 * x**2 * c2
+    vc = dt - bq * x**3 * c3
     pcdot = -qovr0 / br * x * c1
     vcdot = 1 - bq / br * x**2 * c2
 

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -3,8 +3,9 @@ from __future__ import division
 import sys
 import math
 from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
-                  cos, cosh, exp, log, ndarray, newaxis, ones_like, pi, power,
-                  repeat, sin, sinh, squeeze, sqrt, sum, tan, tanh, zeros_like)
+                  clip, cos, cosh, exp, log, ndarray, newaxis, ones_like, pi,
+                  power, repeat, sin, sinh, squeeze, sqrt, sum, tan, tanh,
+                  zeros_like)
 
 from skyfield.constants import AU_KM, DAY_S, DEG2RAD
 from skyfield.functions import dots, length_of, mxv
@@ -385,14 +386,6 @@ def bracket(num, end1, end2):
     return num
 
 
-def bracket_1d(num, end1, end2):
-    too_low = num < end1
-    too_high = num > end2
-    num[too_low] = end1[too_low]
-    num[too_high] = end2[too_high]
-    return num
-
-
 def find_trunc():
     denom = 2
     factr = 2
@@ -565,7 +558,7 @@ def propagate(position, velocity, t0, t1, gm):
         lower[past] *= 2
         oldx[past] = x[past]
         orb_ind = sum(past, axis=1)
-        x[past] = bracket_1d(lower[past], repeat(-bound, orb_ind), repeat(bound, orb_ind))
+        x[past] = clip(lower[past], repeat(-bound, orb_ind), repeat(bound, orb_ind))
         if (x[past] == oldx[past]).any():
             raise ValueError('The input delta time (dt) has a value of {0}.'
                              'This is beyond the range of DT for which we '
@@ -579,7 +572,7 @@ def propagate(position, velocity, t0, t1, gm):
         upper[future] *= 2
         oldx[future] = x[future]
         orb_ind = sum(future, axis=1)
-        x[future] = bracket_1d(upper[future], repeat(-bound, orb_ind), repeat(bound, orb_ind))
+        x[future] = clip(upper[future], repeat(-bound, orb_ind), repeat(bound, orb_ind))
         if (x[future] == oldx[future]).any():
             raise ValueError('The input delta time (dt) has a value of {0}.'
                              'This is beyond the range of DT for which we '

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -587,28 +587,28 @@ def propagate(position, velocity, t0, t1, gm):
 
     lcount = zeros_like(dt)
     mostc = ones_like(dt)*1000
-    not_done = (lower < x) * (x < upper)
+    not_done = (lower < x) & (x < upper)
 
     while not_done.any():
         orb_inds = sum(not_done, axis=1)
         kfun[not_done] = kepler_1d(x[not_done], orb_inds)
 
-        high = (kfun > dt) * not_done
-        low = (kfun < dt) * not_done
-        same = (~high * ~low) * not_done
+        high = (kfun > dt) & not_done
+        low = (kfun < dt) & not_done
+        same = (~high & ~low) & not_done
 
         upper[high] = x[high]
         lower[low] = x[low]
         upper[same] = lower[same] = x[same]
 
-        condition = not_done * (mostc > 64) * (upper != 0) * (lower != 0)
+        condition = not_done & (mostc > 64) & (upper != 0) & (lower != 0)
         mostc[condition] = 64
         lcount[condition] = 0
 
         # vectorized version of min(upper, max(lower, (upper + lower)/2))
         x[not_done] = amin(array([upper[not_done], amax(array([lower[not_done], (lower[not_done]+upper[not_done])/2]), axis=0)]), axis=0)
         lcount += 1
-        not_done = (lower < x) * (x < upper) * (lcount < mostc)
+        not_done = (lower < x) & (x < upper) & (lcount < mostc)
 
     c0, c1, c2, c3 = stumpff(f*x*x)
     br = br0*c0 + x*(b2rv*c1 + x*(bq*c2))

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -3,9 +3,8 @@ from __future__ import division
 import sys
 import math
 from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
-                  atleast_2d, cos, cosh, exp, log, ndarray, newaxis,
-                  ones_like, pi, power, repeat, sin, sinh, squeeze, sqrt, sum,
-                  tan, tanh, zeros_like)
+                  cos, cosh, exp, log, ndarray, newaxis, ones_like, pi, power,
+                  repeat, sin, sinh, squeeze, sqrt, sum, tan, tanh, zeros_like)
 
 from skyfield.constants import AU_KM, DAY_S, DEG2RAD
 from skyfield.functions import dots, length_of, mxv, crosses

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -7,11 +7,12 @@ from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
                   repeat, sin, sinh, squeeze, sqrt, sum, tan, tanh, zeros_like)
 
 from skyfield.constants import AU_KM, DAY_S, DEG2RAD
-from skyfield.functions import dots, length_of, mxv, crosses
+from skyfield.functions import dots, length_of, mxv
 from skyfield.descriptorlib import reify
 from skyfield.elementslib import OsculatingElements, normpi
 from skyfield.units import Distance, Velocity
 from skyfield.vectorlib import VectorFunction
+from skyfield.sgp4lib import _cross
 
 _CONVERT_GM = DAY_S * DAY_S / AU_KM / AU_KM / AU_KM
 
@@ -486,13 +487,13 @@ def propagate(position, velocity, t0, t1, gm):
     r0 = length_of(position)
     rv = dots(position, velocity)
 
-    hvec = crosses(position, velocity)
+    hvec = _cross(position, velocity)
     h2 = dots(hvec, hvec)
 
     if (h2 == 0).any():
         raise ValueError('Motion is not conical')
 
-    eqvec = crosses(velocity, hvec)/gm + -position/r0
+    eqvec = _cross(velocity, hvec)/gm + -position/r0
     e = length_of(eqvec)
     q = h2 / (gm * (1+e))
 

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -438,7 +438,7 @@ def stumpff(x):
 
     mid = ~(low|high)
     if sum(mid):
-        numerators = repeat(x[mid][newaxis].T, trunc-1, axis=1)
+        numerators = repeat(x[mid][:, newaxis], trunc-1, axis=1)
         numerators[:, 1::2] *= -1
         c3[mid] = sum(power(numerators, exponents)/odd_factorials, axis=1)
         c2[mid] = sum(power(numerators, exponents)/even_factorials, axis=1)

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -602,7 +602,7 @@ def propagate(position, velocity, t0, t1, gm):
         not_done = (lower < x) & (x < upper) & (lcount < mostc)
 
     c0, c1, c2, c3 = stumpff(f*x*x)
-    br = br0*c0 + x*(b2rv*c1 + x*(bq*c2))
+    br = br0*c0 + x*(b2rv*c1 + x*bq*c2)
 
     pc = 1 - qovr0 * x * x * c2
     vc = dt - bq * x**3 * c3

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -377,15 +377,6 @@ def ele_to_vec(p, e, i, Om, w, v, mu):
 dpmax = sys.float_info.max
 
 
-def bracket(num, end1, end2):
-    low = num<end1
-    high = num>end2
-
-    num[low] = repeat(end1, sum(low, axis=1))
-    num[high] = repeat(end2, sum(high, axis=1))
-    return num
-
-
 def find_trunc():
     denom = 2
     factr = 2
@@ -540,7 +531,10 @@ def propagate(position, velocity, t0, t1, gm):
     # shape of 2 dimensional arrays from here on out should be (#orbits, len(t1))
     dt = t1 - t0[:, newaxis]
 
-    x = bracket(dt/bq, -bound, bound)
+    x = dt/bq
+    copyto(x, -bound, where=(x<-bound))
+    copyto(x, bound, where=(x>bound))
+
     kfun = kepler(x)
 
     past = dt < 0

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -610,8 +610,8 @@ def propagate(position, velocity, t0, t1, gm):
         lcount += 1
         not_done = (lower < x) * (x < upper) * (lcount < mostc)
 
-    c0, c1, c2, c3 = stumpff(x*x*f)
-    br = c0*br0 + x*(c1*b2rv + x*(c2*bq))
+    c0, c1, c2, c3 = stumpff(f*x*x)
+    br = br0*c0 + x*(b2rv*c1 + x*(bq*c2))
 
     pc = 1 - qovr0 * x**2 * c2
     vc = dt - bq * x**3 * c3

--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -316,7 +316,7 @@ def true_anomaly_parabolic(p, gm, M):
     delta_t = sqrt(2 * p**3 / gm) * M # from http://www.bogan.ca/orbits/kepler/orbteqtn.html
     periapsis_distance = p / 2
     A = 3 / 2 * sqrt(gm / (2 * periapsis_distance**3)) * delta_t
-    B = (A + (A**2 + 1))**(1/3)
+    B = (A + (A*A + 1))**(1/3)
     return 2 * arctan(B - 1/B)
 
 
@@ -501,7 +501,7 @@ def propagate(position, velocity, t0, t1, gm):
     b = sqrt(q/gm)
 
     br0 = b * r0
-    b2rv = b**2 * rv
+    b2rv = b * b * rv
     bq = b * q
     qovr0 = q / r0
 
@@ -613,10 +613,10 @@ def propagate(position, velocity, t0, t1, gm):
     c0, c1, c2, c3 = stumpff(f*x*x)
     br = br0*c0 + x*(b2rv*c1 + x*(bq*c2))
 
-    pc = 1 - qovr0 * x**2 * c2
+    pc = 1 - qovr0 * x * x * c2
     vc = dt - bq * x**3 * c3
     pcdot = -qovr0 / br * x * c1
-    vcdot = 1 - bq / br * x**2 * c2
+    vcdot = 1 - bq / br * x * x * c2
 
     position_prop = pc[newaxis, :, :]*position[:, :, newaxis] + vc[newaxis, :, :]*velocity[:, :, newaxis]
     velocity_prop = pcdot[newaxis, :, :]*position[:, :, newaxis] + vcdot[newaxis, :, :]*velocity[:, :, newaxis]


### PR DESCRIPTION
I have successfully vectorized `keplerlib.propagate`! All of it's arguments can now be arrays. Just for testing purposes I added a function to `data/mpc.py` that can take a comets dataframe and convert it into a `_KeplerOrbit` object that represents multiple comets.

At the moment `_KeplerOrbit` objects that represent multiple orbits don't play well with other `VectorFunction` objects; I'm not sure what needs to change to fix that.

I haven't added any tests yet since none of the official functions in `data/mpc.py` can handle multiple orbits at a time yet.

Here's an example script:

```
from skyfield.api import Loader
from skyfield.data import mpc
from skyfield.constants import GM_SUN_Pitjeva_2005_km3_s2 as GM_SUN
from numpy import arange, linspace, rollaxis
import matplotlib.pyplot as plt

load = Loader('~/projects/skyfield-data')

ts = load.timescale()

with load.open(mpc.COMET_URL) as f:
    comets = mpc.load_comets_dataframe(f)

comets_df = (comets.sort_values('reference')
          .groupby('designation', as_index=False).last()
          .set_index('designation', drop=False))

rows = comets_df.iloc[20:40]

comets = mpc._comet_orbits(rows, ts, GM_SUN)

t = ts.utc(linspace(2000, 2030, 100))
position = comets.at(t).position.au

plt.rcParams['legend.fontsize'] = 10

fig = plt.figure()
ax = fig.gca(projection='3d')

for i, (x, y, z) in enumerate(rollaxis(position, 1)):
    ax.plot(x, y, z, label=rows.designation[i])

ax.legend()

plt.show()
```
Which generates this plot:

![Figure_1](https://user-images.githubusercontent.com/20689997/102707191-d7d3a000-4266-11eb-99b4-9ef421f591d3.png)
