### PR TITLE
Vectorize `mpc.mpc_orbit`, `mpc.comet_orbit`

### DIFF
--- a/skyfield/keplerlib.py
+++ b/skyfield/keplerlib.py
@@ -3,9 +3,9 @@ from __future__ import division
 import sys
 import math
 from numpy import(abs, amax, amin, arange, arccos, arctan, array, atleast_1d,
-                  clip, copy, copyto, cos, cosh, exp, full_like, log, ndarray,
-                  newaxis, pi, power, repeat, sin, sinh, squeeze, sqrt, sum,
-                  tan, tanh, zeros_like)
+                  clip, copy, copyto, cos, cosh, exp, float64, full_like, log,
+                  ndarray, newaxis, pi, power, repeat, sin, sinh, squeeze,
+                  sqrt, sum, tan, tanh, zeros_like)
 
 from skyfield.constants import AU_KM, DAY_S, DEG2RAD
 from skyfield.functions import dots, length_of, mxv
@@ -187,16 +187,13 @@ class _KeplerOrbit(VectorFunction):
         target : int
             NAIF ID of the secondary body
         """
-        M = DEG2RAD * mean_anomaly_degrees
         gm_au3_d2 = gm_km3_s2 * _CONVERT_GM
-        if eccentricity < 1.0:
-            E = eccentric_anomaly(eccentricity, M)
-            v = true_anomaly_closed(eccentricity, E)
-        elif eccentricity > 1.0:
-            E = eccentric_anomaly(eccentricity, M)
-            v = true_anomaly_hyperbolic(eccentricity, E)
-        else:
-            v = true_anomaly_parabolic(semilatus_rectum_au, gm_au3_d2, M)
+        v = true_anomaly(
+            eccentricity,
+            DEG2RAD * mean_anomaly_degrees,
+            semilatus_rectum_au,
+            gm_au3_d2,
+        )
 
         pos, vel = ele_to_vec(
             semilatus_rectum_au,
@@ -268,6 +265,30 @@ class _KeplerOrbit(VectorFunction):
         return '<{0}>'.format(str(self))
 
 
+def true_anomaly(e, M, p, gm):
+    return_scalar = True if isinstance(e, (float, float64)) else False
+    e, M, p = atleast_1d(e, M, p)
+
+    closed = e < 1.0
+    hyperbolic = e > 1.0
+    parabolic = ~closed & ~hyperbolic
+
+    v = zeros_like(e)
+
+    E_closed = eccentric_anomaly(e[closed], M[closed])
+    v[closed] = 2.0 * arctan(sqrt((1.0 + e[closed]) / (1.0 - e[closed])) * tan(E_closed/2))
+
+    E_hyperbolic = eccentric_anomaly(e[hyperbolic], M[hyperbolic])
+    v[hyperbolic] = 2.0 * arctan(sqrt((e[hyperbolic] + 1.0) / (e[hyperbolic] - 1.0)) * tanh(E_hyperbolic/2))
+
+    v[parabolic] = true_anomaly_parabolic(p[parabolic], gm, M[parabolic])
+
+    if return_scalar:
+        return v[0]
+    else:
+        return v
+
+
 def eccentric_anomaly(e, M):
     """ Iterates to solve Kepler's equation to find eccentric anomaly
 
@@ -278,33 +299,22 @@ def eccentric_anomaly(e, M):
     E = M + e*sin(M)
 
     max_iters = 100
-    iters = 0
+    dM = M - (E - e*sin(E))
+    dE = dM/(1 - e*cos(E))
+    not_done = abs(dE) > 1e-14
+    iters = 1
     while iters < max_iters:
-        dM = M - (E - e*sin(E))
-        dE = dM/(1 - e*cos(E))
-        E = E + dE
-        if abs(dE) < 1e-14: return E
+        if not not_done.any():
+            break
+        dM[not_done] = M[not_done] - (E[not_done] - e[not_done]*sin(E[not_done]))
+        dE[not_done] = dM[not_done]/(1 - e[not_done]*cos(E[not_done]))
+        E[not_done] += dE[not_done]
         iters += 1
+        not_done = abs(dE) > 1e-14
+
     else:
-        raise ValueError('Failed to converge')
-
-
-def true_anomaly_hyperbolic(e, E):
-    """Calculates true anomaly from eccentricity and eccentric anomaly.
-
-    Valid for hyperbolic orbits. Equations from the relevant Wikipedia entries.
-
-    """
-    return 2.0 * arctan(sqrt((e + 1.0) / (e - 1.0)) * tanh(E/2))
-
-
-def true_anomaly_closed(e, E):
-    """Calculates true anomaly from eccentricity and eccentric anomaly.
-
-    Valid for closed orbits. Equations from the relevant Wikipedia entries.
-
-    """
-    return 2.0 * arctan(sqrt((1.0 + e) / (1.0 - e)) * tan(E/2))
+        raise ValueError('failed to converge')
+    return E
 
 
 def true_anomaly_parabolic(p, gm, M):
@@ -611,7 +621,7 @@ def propagate(position, velocity, t0, t1, gm):
     pcdot = -qovr0 / br * x * c1
     vcdot = 1 - bq / br * x * x * c2
 
-    position_prop = pc[newaxis, :, :]*position[:, :, newaxis] + vc[newaxis, :, :]*velocity[:, :, newaxis]
-    velocity_prop = pcdot[newaxis, :, :]*position[:, :, newaxis] + vcdot[newaxis, :, :]*velocity[:, :, newaxis]
+    position_prop = pc.T[newaxis, :, :]*position[:, newaxis, :] + vc.T[newaxis, :, :]*velocity[:, newaxis, :]
+    velocity_prop = pcdot.T[newaxis, :, :]*position[:, newaxis, :] + vcdot.T[newaxis, :, :]*velocity[:, newaxis, :]
 
     return squeeze(position_prop), squeeze(velocity_prop)

--- a/skyfield/tests/test_keplerlib.py
+++ b/skyfield/tests/test_keplerlib.py
@@ -74,6 +74,31 @@ def test_minor_planet():
     assert abs(ra.hours - 23.1437) < 0.00005
     assert abs(dec.degrees - -17.323) < 0.0005
 
+def test_minor_planets():
+    text = (b'00001    3.4   0.15 K205V 162.68631   73.73161   80.28698'
+            b'   10.58862  0.0775571  0.21406009   2.7676569  0 MPO492748'
+            b'  6751 115 1801-2019 0.60 M-v 30h Williams   0000      '
+            b'(1) Ceres              20190915\n'
+            b'00001    3.4   0.15 K205V 162.68631   73.73161   80.28698'
+            b'   10.58862  0.0775571  0.21406009   2.7676569  0 MPO492748'
+            b'  6751 115 1801-2019 0.60 M-v 30h Williams   0000      '
+            b'(1) Ceres              20190915\n')
+
+    ts = load.timescale()
+    t = ts.utc(2020, 6, 17)
+    eph = load('de421.bsp')
+    df = mpc.load_mpcorb_dataframe(BytesIO(text))
+
+    assert (df.designation_packed.values == '00001').all()
+    assert (df.designation.values == '(1) Ceres').all()
+
+    ceres = mpc.mpcorb_orbit(df, ts, GM_SUN)
+    ra, dec, distance = eph['earth'].at(t).observe(eph['sun'] + ceres).radec()
+
+    assert (ceres.target == '(1) Ceres').all()
+    assert (abs(ra.hours - 23.1437) < 0.00005).all()
+    assert (abs(dec.degrees - -17.323) < 0.0005).all()
+
 def test_comet():
     text = (b'    CJ95O010  1997 03 29.6333  0.916241  0.994928  130.6448'
             b'  283.3593   88.9908  20200224  -2.0  4.0  C/1995 O1 (Hale-Bopp)'
@@ -102,6 +127,37 @@ def test_comet():
         assert abs(distance.au - 43.266) < 0.0005
 
         assert k.target == 'C/1995 O1 (Hale-Bopp)'
+
+def test_comets():
+    text = (b'    CJ95O010  1997 03 29.6333  0.916241  0.994928  130.6448'
+            b'  283.3593   88.9908  20200224  -2.0  4.0  C/1995 O1 (Hale-Bopp)'
+            b'                                    MPC106342\n'
+            b'    CJ95O010  1997 03 29.6333  0.916241  0.994928  130.6448'
+            b'  283.3593   88.9908  20200224  -2.0  4.0  C/1995 O1 (Hale-Bopp)'
+            b'                                    MPC106342\n')
+
+    ts = load.timescale()
+    t = ts.utc(2020, 5, 31)
+    eph = load('de421.bsp')
+    e = eph['earth'].at(t)
+
+    for loader in mpc.load_comets_dataframe, mpc.load_comets_dataframe_slow:
+        df = loader(BytesIO(text))
+        k = mpc.comet_orbit(df, ts, GM_SUN)
+        p = e.observe(eph['sun'] + k)
+        ra, dec, distance = p.radec()
+
+        # The file authorities/mpc-hale-bopp in the repository is the
+        # source of these angles.  TODO: can we tighten this bound and
+        # drive it to fractions of an arcsecond?
+
+        ra_want = Angle(hours=(23, 59, 16.6))
+        dec_want = Angle(degrees=(-84, 46, 58))
+        assert (abs(ra_want.arcseconds() - ra.arcseconds()) < 2.0).all()
+        assert (abs(dec_want.arcseconds() - dec.arcseconds()) < 0.2).all()
+        assert (abs(distance.au - 43.266) < 0.0005).all()
+
+        assert (k.target == 'C/1995 O1 (Hale-Bopp)').all()
 
 def test_comet_with_eccentricity_of_exactly_one():
     ts = load.timescale()


### PR DESCRIPTION
This commit is only changes that are necessary to vectorize the creation of `_KelperOrbit` objects. This allows the `at()` method to work but not the `.observe` method. This PR needs to be merged before #526.

In order for the tests to pass I need to change them so that they don't use `VectorSum` objects or the `observe` method.