### PR TITLE
Tighten tolerances in event finding routines

### DIFF
--- a/skyfield/searchlib.py
+++ b/skyfield/searchlib.py
@@ -66,7 +66,7 @@ def _find_discrete(ts, jd, f, epsilon, num):
             y = y.take(indices + 1)
             # Keep only the last of several zero crossings that might
             # possibly be separated by less than epsilon.
-            mask = concatenate(((diff(ends) > 3.0 * epsilon), (True,)))
+            mask = concatenate(((diff(ends) > epsilon), (True,)))
             ends = ends[mask]
             y = y[mask]
             break

--- a/skyfield/sgp4lib.py
+++ b/skyfield/sgp4lib.py
@@ -272,7 +272,7 @@ class EarthSatellite(VectorFunction):
         doublets = repeat(concatenate(((t0.tt,), jdmax, (t1.tt,))), 2)
         jdo = (doublets[:-1] + doublets[1:]) / 2.0
 
-        trs, rs = _find_discrete(t0.ts, jdo, below_horizon_at, half_second, 8)
+        trs, rs = _find_discrete(t0.ts, jdo, below_horizon_at, half_second/4, 8)
 
         jd = concatenate((jdmax, trs.tt))
         v = concatenate((ones, rs * 2))


### PR DESCRIPTION
Fixes #559.

This PR tightens tolerances as discussed in #559. It's enough to fix the particular bugs in that issue, and makes that kind of bug less likely but doesn't completely prevent it. Do you think these tolerances should be decreased more so errors are even less likely?

Ideally there would be a more thorough fix that would make those kind of bugs impossible rather than just unlikely. I'll keep thinking about it, but for now this is enough to get @bmatthiesen's scripts working.