### PR TITLE
Fix bug in twilight calculation example script

### DIFF
--- a/skyfield/documentation/examples.rst
+++ b/skyfield/documentation/examples.rst
@@ -96,7 +96,7 @@ or how early I need to rise to see the morning sky:
     f = almanac.dark_twilight_day(eph, bluffton)
     times, events = almanac.find_discrete(t0, t1, f)
 
-    previous_e = f(t0)
+    previous_e = f(t0).item()
     for t, e in zip(times, events):
         tstr = str(t.astimezone(zone))[:16]
         if previous_e < e:


### PR DESCRIPTION
I found this bug when looking into discussion #597.

The example script [here](https://rhodesmill.org/skyfield/examples.html#when-will-it-get-dark-tonight) defines `previous_e` as an `ndarray` of size 1. This isn't a problem as long as the first branch of the if statement is used, but the second branch uses `previous_e` as a key to the `almanac.TWILIGHTS` dictionary which expects an integer, thus causing the error.

I was originally going to suggest using `np.isscalar` to convert the `ndarray` to an integer, but the [documentation](https://numpy.org/doc/stable/reference/generated/numpy.asscalar.html) says that function is deprecated and recommends the `item()` method instead.