### PR TITLE
Fix Calculation of GM in `osculating_elements_of()`, etc.

### DIFF
--- a/skyfield/data/gravitational_parameters.py
+++ b/skyfield/data/gravitational_parameters.py
@@ -82,3 +82,6 @@ GM_dict = {
     2000511: 2.3312860000000000E+00,
     2000704: 2.3573170000000001E+00,
     }
+
+non_barycenters = [id for id in GM_dict.keys() if id not in range(1, 10)]
+GM_dict[0] = sum([GM_dict[id] for id in non_barycenters])

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -31,9 +31,9 @@ def osculating_elements_of(position, reference_frame=None, gm_km3_s2=None):
         if position.center not in range(0, 10): # true if position.center is not a barycenter
             gm_km3_s2 += GM_dict.get(position.target, 0)
 
-    if gm_km3_s2 == 0:
-        raise ValueError("Skyfield is unable to calculate a value for GM. You"
-                " should specify one using the 'gm_km3_s2' keyword argument")
+        if gm_km3_s2 == 0:
+            raise ValueError("Skyfield is unable to calculate a value for GM. You"
+                    " should specify one using the 'gm_km3_s2' keyword argument")
 
     if reference_frame is not None:
         position_vec = Distance(reference_frame.dot(position.position.au))

--- a/skyfield/elementslib.py
+++ b/skyfield/elementslib.py
@@ -12,12 +12,19 @@ from numpy import (array, arctan2, sin, arctan, tan, inf, repeat, float64,
 def osculating_elements_of(position, reference_frame=None, gm_km3_s2=None):
     """Produce the osculating orbital elements for a position.
 
-    The ``position`` should be an :class:`~skyfield.positionlib.ICRF`
-    instance like that returned by the ``at()`` method of any Solar
-    System body, specifying a position, a velocity, and a time.  An
-    instance of :class:`~skyfield.elementslib.OsculatingElements` is
-    returned.
+    Parameters
+    ----------
+    position : :class:`~skyfield.positionlib.ICRF` object
+         commonly returned by the ``at()`` method of any Solar System body
+    reference_frame: 3x3 numpy array, optional
+        commonly used values are found in skyfield.data.spice.inertial_frames
+    gm_km3_s2: float, optional
+        Gravitational parameter (G*M) in units of km^3/s^2
+        If not specified, this is calculated for you.
 
+    Returns
+    -------
+    :class:`~skyfield.elementslib.OsculatingElements`
     """
     if not gm_km3_s2:
         gm_km3_s2 = GM_dict.get(position.center, 0)

--- a/skyfield/tests/test_elementslib.py
+++ b/skyfield/tests/test_elementslib.py
@@ -1,5 +1,6 @@
 from skyfield.api import load, Time, load_file
 from skyfield.data.spice import inertial_frames
+from skyfield.data.gravitational_parameters import GM_dict
 from skyfield.units import Distance, Angle, Velocity
 from skyfield.constants import DAY_S
 from skyfield.elementslib import (
@@ -594,3 +595,15 @@ def test_all_types_at_once(ts):
                 w=array([ 0, 0,    0,  4,  4,    2, 4, 4,    2,   4,   4,    2]),
                 v=array([ 1, 5,    3,  5,  5,    3, 5, 5,    3,  .5,  .5,   .5]),
                 ts=ts)
+
+def test_gm_calculation(ts):
+    geocentric_pos = (moon - earth).at(ts.tdb(2015, 3, 2, 2))
+    geocentric_elements = osculating_elements_of(geocentric_pos, ECLIPTIC)
+    assert geocentric_elements._mu == GM_dict[3]
+
+    barycentric_pos = earth.at(ts.tdb(2015, 3, 2, 2))
+    barycentric_elements = osculating_elements_of(barycentric_pos, ECLIPTIC)
+    assert barycentric_elements._mu == GM_dict[0]
+
+    assert osculating_elements_of(barycentric_pos, ECLIPTIC, GM_dict[0])._mu == barycentric_elements._mu
+


### PR DESCRIPTION
- fixes calculation of GM in `osculating_elements_of()`
- Adds calculated value for solar system barycenter to `skyfield.data.gravitational_parameters.GM_dict`. This is calculated by summing all of the masses in `GM_dict` that aren't barycenters.
- Add keyword argument to `osculating_elements_of()`. I named this argument `gm_km3_s2` to match the arguments @brandon-rhodes used in `data.mpc.py`. Most places in skyfield use `gm_km3_s2` as the argument name and I think that's the best and most explicit option. I believe `OsculatingElements.__init__()` is the last place in the public api using 'mu' in a parameter name, is there a way to deprecate this without breaking backwards compatibility?
- Make the doc string for `osculating_elements_of` more informative