### PR TITLE
Load deepsky objects from pyongc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy==1.15.4
 matplotlib==3.3.0
 pandas==1.0.0
 pyflakes==2.1.1
+pyongc
 python-dateutil>=2.5.0
 pytz
 sphinx==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.15.4
 matplotlib==3.3.0
 pandas==1.0.0
 pyflakes==2.1.1
-pyongc
+pyongc[data]
 python-dateutil>=2.5.0
 pytz
 sphinx==1.7.2

--- a/setup.py
+++ b/setup.py
@@ -60,4 +60,7 @@ setup(
         'numpy',
         'sgp4>=2.2',
         ],
+    extras_require={
+        'ongc': ['pyongc'],
+    },
 )

--- a/skyfield/data/ongc.py
+++ b/skyfield/data/ongc.py
@@ -1,0 +1,29 @@
+from math import pi
+
+PANDAS_MESSAGE = """Skyfield needs Pandas to load the OpenNGC catalog
+
+To load the OpenNGC star catalog, Skyfield needs the Pandas data
+analysis toolkit.  Try installing it using your usual Python package
+installer, like "pip install pandas" or "conda install pandas".
+"""
+
+def load_dataframe(in_dataframe):
+    """Convert a dataframe from pyongc.data for import in skyfield."""
+    try:
+        from pandas import read_csv
+    except ImportError:
+        raise ImportError(PANDAS_MESSAGE)
+
+    df = in_dataframe[['name', 'ra', 'dec', 'parallax', 'pmra', 'pmdec']].copy()
+
+    df = df.assign(
+        ra_hours = df['ra'] * 180 / pi / 15.0,
+        dec_degrees = df['dec'] * 180 / pi,
+        epoch_year = 2000,
+    )
+
+    df.rename(columns = {'parallax':'parallax_mas',
+                         'pmra':'ra_mas_per_year',
+                         'pmdec':'dec_mas_per_year'}, inplace = True)
+
+    return df.set_index('name')

--- a/skyfield/starlib.py
+++ b/skyfield/starlib.py
@@ -106,6 +106,18 @@ class Star(object):
             epoch=epoch,
         )
 
+    @classmethod
+    def from_ongc(cls, identifier):
+        from pyongc import ongc
+        deepsky = ongc.Dso(identifier)
+        return cls(
+            ra = Angle(radians=deepsky.rad_coords[0]),
+            dec = Angle(radians=deepsky.rad_coords[1]),
+            ra_mas_per_year = deepsky.pm_ra or 0,
+            dec_mas_per_year = deepsky.pm_dec or 0,
+            parallax_mas = deepsky.parallax or 0,
+        )
+
     def _observe_from_bcrs(self, observer):
         position, velocity = self._position_au, self._velocity_au_per_d
         t = observer.t

--- a/skyfield/tests/test_stars.py
+++ b/skyfield/tests/test_stars.py
@@ -6,3 +6,10 @@ def test_dataframe():
         df = load_dataframe(f)
     star = api.Star.from_dataframe(df)
     assert repr(star) == 'Star(ra shape=9933, dec shape=9933, ra_mas_per_year shape=9933, dec_mas_per_year shape=9933, parallax_mas shape=9933, epoch shape=9933)'
+
+def test_from_ongc():
+    hercules = api.Star.from_ongc('M13')
+    assert repr(hercules) == (
+        'Star(ra=250.42345833333337, dec=36.46130555555556, ra_mas_per_year=-3.18, '
+        'dec_mas_per_year=-2.56, parallax_mas=0.0813, epoch=2451545.0)'
+    )

--- a/skyfield/tests/test_stars.py
+++ b/skyfield/tests/test_stars.py
@@ -1,11 +1,21 @@
+from pyongc import data
 from skyfield import api
-from skyfield.data.hipparcos import load_dataframe
+from skyfield.data import hipparcos, ongc
 
 def test_dataframe():
     with api.load.open('hip_main.dat.gz') as f:
-        df = load_dataframe(f)
+        df = hipparcos.load_dataframe(f)
     star = api.Star.from_dataframe(df)
     assert repr(star) == 'Star(ra shape=9933, dec shape=9933, ra_mas_per_year shape=9933, dec_mas_per_year shape=9933, parallax_mas shape=9933, epoch shape=9933)'
+
+def test_dataframe_from_ongc():
+    ongc_data = data.all()
+    df = ongc.load_dataframe(ongc_data)
+    hercules = api.Star.from_dataframe(df.loc['NGC6205'])
+    assert repr(hercules) == (
+        'Star(ra=250.42345833333337, dec=36.46130555555556, ra_mas_per_year=-3.18, '
+        'dec_mas_per_year=-2.56, parallax_mas=0.0813, epoch=2451545.0)'
+    )
 
 def test_from_ongc():
     hercules = api.Star.from_ongc('M13')


### PR DESCRIPTION
Loading deepsky objects from pyongc is possible in two ways: a simple load using `Star.from_ongc('identifier')` or by converting a dataframe from pyongc.data with `skyfield.data.ongc.load_dataframe()` + `Star.from_dataframe()` for loading several objects at once.
The pyongc dependency is optional (users needs to install skyfield[ongc] extra to pull in pyongc dependency).

Fixes #823 