### PR TITLE
Fix compatibility with numpy >= 1.23.5

### DIFF
--- a/skyfield/tests/test_elementslib.py
+++ b/skyfield/tests/test_elementslib.py
@@ -423,7 +423,7 @@ def check_orbit(p, e, i, Om, w, v, ts):
                                   time, mu)
     check_types(elements, length)
     compare(time, elements.time, 1e-9)
-    compare(elements.semi_latus_rectum.km, p, 1e-9)
+    compare(elements.semi_latus_rectum.km, p, 1e-8)
     compare(elements.eccentricity, e, 1e-14)
     compare(elements.inclination.radians, i, 1e-14, mod=True)
     compare(elements.longitude_of_ascending_node.radians, Om, 1e-14, mod=True)

--- a/skyfield/tests/test_planetarylib.py
+++ b/skyfield/tests/test_planetarylib.py
@@ -45,14 +45,14 @@ def test_frame_rotation_matrices():
     desired_rate = np.array(desired_rate) * DAY_S
 
     R = frame.rotation_at(ts.tdb_jd(tdb))
-    assert (R == desired_rotation).all()  # Boom.
+    assert abs(R - desired_rotation).max() < 3e-16
 
     R2, Rv = frame.rotation_and_rate_at(ts.tdb_jd(tdb))
     assert (R == R2).all()
     if IS_32_BIT:
         assert abs(Rv - desired_rate).max() < 3e-26
     else:
-        assert (Rv == desired_rate).all()  # Boom.
+        assert abs(Rv - desired_rate).max() < 3e-17
 
     # Second, a moment when the angle W is more than 2500 radians.
 
@@ -107,14 +107,14 @@ def test_frame_rotation_matrices():
     if IS_32_BIT:
         assert abs(R - desired_rotation).max() < 2e-16
     else:
-        assert (R == desired_rotation).all()
+        assert abs(R - desired_rotation).max() < 4e-16
 
     R2, Rv = frame.rotation_and_rate_at(ts.tdb_jd(tdb))
     assert (R == R2).all()
     if IS_32_BIT:
         assert abs(Rv - desired_rate).max() < 2e-18
     else:
-        assert (Rv == desired_rate).all()
+        assert abs(Rv - desired_rate).max() < 6e-17
 
 def test_rotating_vector_into_frame():
     et_seconds = 259056665.1855896

--- a/skyfield/tests/test_positions.py
+++ b/skyfield/tests/test_positions.py
@@ -139,7 +139,7 @@ def test_position_of_radec():
     ra, dec, distance = p.radec(epoch=epoch)
     assert abs(ra.hours) < 1e-12
     assert abs(dec.degrees) < 1e-12
-    assert abs(distance.au - 1) < 1e-16
+    assert abs(distance.au - 1) < 3e-16
 
 def test_position_from_radec():
     # Only a couple of minimal tests, since the routine is deprecated.

--- a/skyfield/tests/test_positions.py
+++ b/skyfield/tests/test_positions.py
@@ -184,7 +184,7 @@ def test_velocity_in_ITRF_to_GCRS2():
     relative_error = (length_of(actual_motion - predicted_motion)
                       / length_of(actual_motion))
 
-    acceptable_error = 4e-12
+    acceptable_error = 1e-11
     assert relative_error < acceptable_error
 
 def test_light_time_method():


### PR DESCRIPTION
Tested on Ubuntu 22.10 x86_64
Python 3.11.2
nunpy 1.23.5 and 1.24.2

Closes #822 