### PR TITLE
Fixed units of ndot and nddot in earth-satellites.rst.

### DIFF
--- a/skyfield/documentation/earth-satellites.rst
+++ b/skyfield/documentation/earth-satellites.rst
@@ -889,8 +889,8 @@ that builds a satellite model directly from numeric orbital parameters:
         5,               # satnum: Satellite number
         18441.785,       # epoch: days since 1949 December 31 00:00 UT
         2.8098e-05,      # bstar: drag coefficient (/earth radii)
-        6.969196665e-13, # ndot: ballistic coefficient (revs/day)
-        0.0,             # nddot: second derivative of mean motion (revs/day^3)
+        6.969196665e-13, # ndot: ballistic coefficient (radians/minute^2)
+        0.0,             # nddot: second derivative of mean motion (radians/minute^3)
         0.1859667,       # ecco: eccentricity
         5.7904160274885, # argpo: argument of perigee (radians)
         0.5980929187319, # inclo: inclination (radians)


### PR DESCRIPTION
Updated the documentation with correct units for ndot and nddot.
Related: https://github.com/brandon-rhodes/python-sgp4/pull/115

From the other PR for reference:

In the project documentation, ndot is specified as units "revs/day" and nddot is "revs/day^3", however the actual implemented units are radians/minute^2 and radians/minute^3. This PR just brings the documentation in line with the code.

See following examples:
```python
>>> from sgp4.api import Satrec
>>> from astropy.units import Quantity

>>> # Parse a TLE with:
>>> #   ndot = .00000205 revs/day^2
>>> #   nddot = 0.2125e-5 revs/day^3
>>> #                                          ndot       nddot
>>> line1 = "1 00005U 58002B   23070.26627551  .00000205  21250-5  25732-3 6  9996"
>>> line2 = "2 00005  34.2487  37.1068 1845867 158.6970 210.1812 10.85070135313524"

>>> sat = Satrec.twoline2rv(line1, line2)
>>> sat.ndot
6.21167528921593e-12

>>> Quantity(.00000205, "cycle/day^2").to_value("radian/minute^2")
6.211675289215929e-12

>>> sat.nddot
4.471480348775017e-15

>>> Quantity(0.2125e-5, "cycle/day^3").to_value("radian/minute^3")
4.471480348775017e-15
```

```python
>>> from sgp4.api import Satrec, WGS72

>>> satellite2 = Satrec()
>>> satellite2.sgp4init(
...     WGS72,                # gravity model
...     'i',                  # 'a' = old AFSPC mode, 'i' = improved mode
...     25544,                # satnum: Satellite number
...     25545.69339541,       # epoch: days since 1949 December 31 00:00 UT
...     3.8792e-05,           # bstar: drag coefficient (1/earth radii)
...     .00000205,            # ndot: ballistic coefficient (radians/minute^2)
...     0.2125e-5,            # nddot: mean motion 2nd derivative (radians/minute^3)
...     0.0007417,            # ecco: eccentricity
...     0.3083420829620822,   # argpo: argument of perigee (radians)
...     0.9013560935706996,   # inclo: inclination (radians)
...     1.4946964807494398,   # mo: mean anomaly (radians)
...     0.06763602333248933,  # no_kozai: mean motion (radians/minute)
...     3.686137125541276,    # nodeo: R.A. of ascending node (radians)
... )

>>> satellite2.ndot
2.05e-06

>>> satellite2.nddot
2.125e-06
```