### PR TITLE
numpy 2.0 removed np.float_

### DIFF
--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -5,9 +5,8 @@ import sys
 from collections import namedtuple
 from datetime import date, datetime, timedelta
 from numpy import (
-    array, concatenate, cos, float_, int64, isnan, isinf, linspace,
+    array, concatenate, cos, float64, int64, isnan, isinf, linspace,
     nan, ndarray, nonzero, pi, rollaxis, searchsorted, sin, where, zeros_like,
-
 )
 from time import strftime, struct_time
 from ._compatibility import interp


### PR DESCRIPTION
```
Numpy: 2.0.0.dev0+git20230828.ef0fd39
...
skyfield/timelib.py:7: in <module>
    from numpy import (
E   ImportError: cannot import name 'float_' from 'numpy' (numpy/__init__.py)
```

xref https://github.com/astropy/astropy/pull/15235