### PR TITLE
Resolve AttributeError in satellite_download.py 

### DIFF
--- a/examples/satellite_download.py
+++ b/examples/satellite_download.py
@@ -6,5 +6,5 @@ name = 'stations.csv'  # custom filename, not 'gp.php'
 base = 'https://celestrak.org/NORAD/elements/gp.php'
 url = base + '?GROUP=stations&FORMAT=csv'
 
-if not load.exists(name) or load.days_old(name) >= max_days:
+if not load._exists(name) or load.days_old(name) >= max_days:
     load.download(url, filename=name)


### PR DESCRIPTION
- It looks like an underscore is needed before the `exists()` method on the example for downloading element sets from [this webpage](https://rhodesmill.org/skyfield/earth-satellites.html). 
- Running the code from the example throws an error: `AttributeError: 'Loader' object has no attribute 'exists'. Did you mean: '_exists'?`
- This PR changes `exists()` to `_exists()` in satellite_download.py 