### PR TITLE
Use arctan2 instead of arcsin when converting to spherical coordinates

### DIFF
--- a/skyfield/functions.py
+++ b/skyfield/functions.py
@@ -2,7 +2,7 @@
 
 from numpy import (
     arcsin, arctan2, array, cos, einsum, finfo, float64,
-    full_like, load, nan, rollaxis, sin, sqrt, where,
+    full_like, hypot, load, nan, rollaxis, sin, sqrt, where,
 )
 from pkgutil import get_data
 from skyfield.constants import tau
@@ -86,7 +86,7 @@ def to_spherical(xyz):
     """
     r = length_of(xyz)
     x, y, z = xyz
-    theta = arcsin(z / (r + _AVOID_DIVIDE_BY_ZERO))
+    theta = arctan2(z, hypot(x, y))
     phi = arctan2(y, x) % tau
     return r, theta, phi
 
@@ -96,7 +96,7 @@ def _to_spherical_and_rates(r, v):
     xdot, ydot, zdot = v
 
     length = length_of(r)
-    lat = arcsin(z / (length + _AVOID_DIVIDE_BY_ZERO))
+    lat = arctan2(z, hypot(x, y));
     lon = arctan2(y, x) % tau
     range_rate = dots(r, v) / length_of(r)
 

--- a/skyfield/functions.py
+++ b/skyfield/functions.py
@@ -1,7 +1,7 @@
 """Basic operations that are needed repeatedly throughout Skyfield."""
 
 from numpy import (
-    arcsin, arctan2, array, cos, einsum, finfo, float64,
+    arctan2, array, cos, einsum, finfo, float64,
     full_like, hypot, load, nan, rollaxis, sin, sqrt, where,
 )
 from pkgutil import get_data

--- a/skyfield/functions.py
+++ b/skyfield/functions.py
@@ -98,7 +98,7 @@ def _to_spherical_and_rates(r, v):
     length = length_of(r)
     lat = arctan2(z, hypot(x, y));
     lon = arctan2(y, x) % tau
-    range_rate = dots(r, v) / length_of(r)
+    range_rate = dots(r, v) / length
 
     x2 = x * x
     y2 = y * y


### PR DESCRIPTION
This pull request avoids using the _AVOID_DIVIDE_BY_ZERO term in two cases.