### PR TITLE
Hotfix/broadcast wgs84 positions regarding #1036

### DIFF
--- a/skyfield/earthlib.py
+++ b/skyfield/earthlib.py
@@ -1,7 +1,7 @@
 """Formulae for specific earth behaviors and effects."""
 
 from numpy import (abs, arcsin, arccos, arctan2, array, clip, cos,
-                   minimum, pi, sin, sqrt, tan, where, zeros_like)
+                   minimum, pi, sin, sqrt, tan, where, zeros_like, dot)
 
 from .constants import (AU_M, ANGVEL, DAY_S, DEG2RAD, ERAD,
                         IERS_2010_INVERSE_EARTH_FLATTENING, RAD2DEG, T0, tau)
@@ -91,7 +91,7 @@ def compute_limb_angle(position_au, observer_au):
 
     # Compute zenith distance of observed object.
 
-    coszd = dots(position_au, observer_au) / (disobj * disobs)
+    coszd = dot(observer_au, position_au) / (disobj * disobs)
     coszd = clip(coszd, -1.0, 1.0)
     zdobj = arccos(coszd)
 

--- a/skyfield/relativity.py
+++ b/skyfield/relativity.py
@@ -1,4 +1,4 @@
-from numpy import abs, einsum, sqrt, where
+from numpy import abs, einsum, sqrt, where, diagonal
 
 from .constants import C, AU_M, C_AUDAY, GS
 from .functions import _AVOID_DIVIDE_BY_ZERO, dots, length_of
@@ -109,6 +109,9 @@ def light_time_difference(position, observer_position):
 
     # Light-time returned is the projection of vector 'pos_obs' onto the
     # unit vector 'u1' (formed from 'pos1'), divided by the speed of light.
+
+    if observer_position.shape == (3,3):
+        observer_position = diagonal(observer_position)
 
     diflt = einsum('a...,a...', u1, observer_position) / C_AUDAY
     return diflt


### PR DESCRIPTION
I implemented the changes discussed in https://github.com/skyfielders/python-skyfield/issues/1036. This allows us to observe the apparent positions of multiple WGS84 locations on earth with a single line of code and without a for loop.

Example script to validate:

```python
from skyfield.api import load, wgs84, EarthSatellite

ts = load.timescale()
t = ts.now()

planets = load('de440.bsp')
earth = planets['earth']
moon = planets['moon']

ts = load.timescale()
line1 = '1 25544U 98067A   14020.93268519  .00009878  00000-0  18200-3 0  5082'
line2 = '2 25544  51.6498 109.4756 0003572  55.9686 274.8005 15.49815350868473'
satellite = EarthSatellite(line1, line2, 'ISS (ZARYA)', ts)

geopos = wgs84.latlon(latitude_degrees = [0,0],
                      longitude_degrees = [0,10])

# View from moon to geographic positions
pos = moon.at(t).observe(geopos+earth).apparent()
print(pos.xyz)

pos1 = moon.at(t).observe(earth + wgs84.latlon(
    latitude_degrees = 0,
    longitude_degrees = 0,
)).apparent()
print(pos1.xyz)

pos2 = moon.at(t).observe(earth + wgs84.latlon(
    latitude_degrees = 0,
    longitude_degrees = 10,
)).apparent()
print(pos2.xyz)


# View from Satellite to geographic positions
pos = (satellite+earth).at(t).observe(geopos+earth).apparent()
print(pos.xyz)

pos1 = (satellite+earth).at(t).observe(earth + wgs84.latlon(
    latitude_degrees = 0,
    longitude_degrees = 0,
)).apparent()
print(pos1.xyz)

pos2 = (satellite+earth).at(t).observe(earth + wgs84.latlon(
    latitude_degrees = 0,
    longitude_degrees = 10,
)).apparent()
print(pos2.xyz)

```


